### PR TITLE
Add parenthesis around some array element

### DIFF
--- a/tsify-macros/src/typescript.rs
+++ b/tsify-macros/src/typescript.rs
@@ -622,9 +622,12 @@ impl Display for TsType {
                 write!(f, "\"{lit}\"")
             }
 
-            TsType::Array(elem) => {
-                write!(f, "{elem}[]")
-            }
+            TsType::Array(elem) => match elem.as_ref() {
+                TsType::Union(_) | TsType::Intersection(_) | &TsType::Option(_) => {
+                    write!(f, "({elem})[]")
+                }
+                _ => write!(f, "{elem}[]"),
+            },
 
             TsType::Tuple(elems) => {
                 let elems = elems


### PR DESCRIPTION
Fix an issue with converting `Vec<Option<T>>` into `T | undefined[]`. Now it generates `(T | undefined)[]`

I don't know how to test this because on my laptop I have this error when running tests (./test.sh) : 
```
     Running tests/expandtest.rs (target/debug/deps/expandtest-ce5eb3473a363e90)

running 1 test
error: no such command: `expand`

	View all installed commands with `cargo --list`
test expandtest ... FAILED
```