### PR TITLE
Update to syn 2

### DIFF
--- a/tsify-macros/Cargo.toml
+++ b/tsify-macros/Cargo.toml
@@ -16,9 +16,8 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = "1.0"
-serde_derive_internals = "0.26"
-darling = "0.14"
+syn = { version = "2.0", default-features = false, features = ["full", "parsing", "printing", "proc-macro"] }
+serde_derive_internals = "0.28"
 
 [features]
 wasm-bindgen = []

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -1,13 +1,4 @@
-use darling::{FromDeriveInput, FromField};
 use serde_derive_internals::ast::Field;
-
-#[derive(Debug, Default, FromDeriveInput)]
-#[darling(attributes(tsify), default)]
-struct TsifyContainerAttarsDef {
-    into_wasm_abi: bool,
-    from_wasm_abi: bool,
-    namespace: bool,
-}
 
 #[derive(Debug, Default)]
 pub struct TsifyContainerAttars {
@@ -16,39 +7,94 @@ pub struct TsifyContainerAttars {
     pub namespace: bool,
 }
 
-impl FromDeriveInput for TsifyContainerAttars {
-    fn from_derive_input(input: &syn::DeriveInput) -> darling::Result<Self> {
-        let TsifyContainerAttarsDef {
-            into_wasm_abi,
-            from_wasm_abi,
-            namespace,
-        } = TsifyContainerAttarsDef::from_derive_input(input)?;
+impl TsifyContainerAttars {
+    pub fn from_derive_input(input: &syn::DeriveInput) -> syn::Result<Self> {
+        let mut attrs = Self {
+            into_wasm_abi: false,
+            from_wasm_abi: false,
+            namespace: false,
+        };
 
-        if namespace && !matches!(input.data, syn::Data::Enum(_)) {
-            Err(darling::Error::custom(
-                "#[tsify(namespace)] can only be used on enums",
-            ))
-        } else {
-            Ok(Self {
-                into_wasm_abi,
-                from_wasm_abi,
-                namespace,
-            })
+        for attr in &input.attrs {
+            if !attr.path().is_ident("tsify") {
+                continue;
+            }
+
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("into_wasm_abi") {
+                    if attrs.into_wasm_abi {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    attrs.into_wasm_abi = true;
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("from_wasm_abi") {
+                    if attrs.from_wasm_abi {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    attrs.from_wasm_abi = true;
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("namespace") {
+                    if !matches!(input.data, syn::Data::Enum(_)) {
+                        return Err(meta.error("#[tsify(namespace)] can only be used on enums"));
+                    }
+                    if attrs.namespace {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    attrs.namespace = true;
+                    return Ok(());
+                }
+
+                Err(meta.error("unsupported tsify attribute, expected one of `into_wasm_abi`, `from_wasm_abi`, `namespace`"))
+            })?;
         }
+
+        Ok(attrs)
     }
 }
 
-#[derive(Debug, Default, FromField)]
-#[darling(attributes(tsify), default)]
+#[derive(Debug, Default)]
 pub struct TsifyFieldAttrs {
-    #[darling(rename = "type")]
     pub type_override: Option<String>,
     pub optional: bool,
 }
 
 impl TsifyFieldAttrs {
-    pub fn from_serde_field(field: &Field) -> darling::Result<Self> {
-        let mut attrs = Self::from_field(field.original)?;
+    pub fn from_serde_field(field: &Field) -> syn::Result<Self> {
+        let mut attrs = Self {
+            type_override: None,
+            optional: false,
+        };
+
+        for attr in &field.original.attrs {
+            if !attr.path().is_ident("tsify") {
+                continue;
+            }
+
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("type") {
+                    if attrs.type_override.is_some() {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    let lit = meta.value()?.parse::<syn::LitStr>()?;
+                    attrs.type_override = Some(lit.value());
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("optional") {
+                    if attrs.optional {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    attrs.optional = true;
+                    return Ok(());
+                }
+
+                Err(meta.error("unsupported tsify attribute, expected one of `type` or `optional`"))
+            })?;
+        }
 
         if let Some(expr) = field.attrs.skip_serializing_if() {
             let path = expr

--- a/tsify-macros/src/derive.rs
+++ b/tsify-macros/src/derive.rs
@@ -4,7 +4,7 @@ use syn::{parse_quote, DeriveInput};
 
 use crate::{container::Container, parser::Parser, wasm_bindgen};
 
-pub fn expand(input: DeriveInput) -> darling::Result<TokenStream> {
+pub fn expand(input: DeriveInput) -> syn::Result<TokenStream> {
     let cont = Container::from_derive_input(&input)?;
 
     let parser = Parser::new(&cont);
@@ -34,7 +34,7 @@ pub fn expand(input: DeriveInput) -> darling::Result<TokenStream> {
     Ok(tokens)
 }
 
-pub fn expand_by_attr(args: TokenStream, input: DeriveInput) -> darling::Result<TokenStream> {
+pub fn expand_by_attr(args: TokenStream, input: DeriveInput) -> syn::Result<TokenStream> {
     let mut cloned_input = input.clone();
     let attr: syn::Attribute = parse_quote!(#[tsify(#args)]);
     cloned_input.attrs.push(attr);

--- a/tsify-macros/src/lib.rs
+++ b/tsify-macros/src/lib.rs
@@ -13,15 +13,15 @@ use syn::{parse_macro_input, DeriveInput};
 fn declare_impl(
     args: proc_macro2::TokenStream,
     item: syn::Item,
-) -> darling::Result<proc_macro2::TokenStream> {
+) -> syn::Result<proc_macro2::TokenStream> {
     match item {
         syn::Item::Type(item) => type_alias::expend(item),
         syn::Item::Enum(item) => derive::expand_by_attr(args, item.into()),
         syn::Item::Struct(item) => derive::expand_by_attr(args, item.into()),
-        _ => Err(darling::Error::custom(
+        _ => Err(syn::Error::new_spanned(
+            args,
             "#[declare] can only be applied to a struct, enum, or type alias.",
-        )
-        .with_span(&args)),
+        )),
     }
 }
 
@@ -34,7 +34,7 @@ pub fn declare(
     let args = proc_macro2::TokenStream::from(args);
 
     declare_impl(args, item)
-        .unwrap_or_else(|err| err.write_errors())
+        .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
 
@@ -43,6 +43,6 @@ pub fn derive_tsify(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let item: DeriveInput = parse_macro_input!(input);
 
     derive::expand(item)
-        .unwrap_or_else(|err| err.write_errors())
+        .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -179,7 +179,7 @@ impl<'a> Parser<'a> {
         let ts_attrs = match TsifyFieldAttrs::from_serde_field(field) {
             Ok(attrs) => attrs,
             Err(err) => {
-                self.container.darling_error(err);
+                self.container.syn_error(err);
                 return (TsType::NEVER, None);
             }
         };

--- a/tsify-macros/src/type_alias.rs
+++ b/tsify-macros/src/type_alias.rs
@@ -3,7 +3,7 @@ use quote::quote;
 
 use crate::{ctxt::Ctxt, decl::TsTypeAliasDecl, typescript::TsType};
 
-pub fn expend(item: syn::ItemType) -> darling::Result<TokenStream> {
+pub fn expend(item: syn::ItemType) -> syn::Result<TokenStream> {
     let ctxt = Ctxt::new();
 
     let type_ann = TsType::from(item.ty.as_ref());

--- a/tsify-macros/src/typescript.rs
+++ b/tsify-macros/src/typescript.rs
@@ -256,7 +256,7 @@ impl TsType {
                     .iter()
                     .filter_map(|p| match p {
                         syn::GenericArgument::Type(t) => Some(t),
-                        syn::GenericArgument::Binding(t) => Some(&t.ty),
+                        syn::GenericArgument::AssocType(t) => Some(&t.ty),
                         _ => None,
                     })
                     .collect();


### PR DESCRIPTION
Fixes #17.

This also switches to syn 2's `syn::meta` library for parsing the attributes. https://docs.rs/syn/2/syn/meta/struct.ParseNestedMeta.html