### PR TITLE
Allow Recursive Affixes on Types

### DIFF
--- a/tests/affixes.rs
+++ b/tests/affixes.rs
@@ -1,0 +1,116 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_prefix() {
+    type MyType = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Special")]
+    struct PrefixedStruct {
+        // Make sure that prefix isn't applied to builtin types
+        x: u32,
+        y: MyType,
+    }
+
+    assert_eq!(
+        PrefixedStruct::DECL,
+        indoc! {"
+            export interface SpecialPrefixedStruct {
+                x: number;
+                y: SpecialMyType;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Special")]
+    enum PrefixedEnum {
+        VariantA(MyType),
+        VariantB(u32),
+    }
+
+    assert_eq!(
+        PrefixedEnum::DECL,
+        indoc! {"
+            export type SpecialPrefixedEnum = { VariantA: SpecialMyType } | { VariantB: number };"
+        }
+    );
+}
+
+#[test]
+fn test_suffix() {
+    type MyType = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_suffix = "Special")]
+    struct SuffixedStruct {
+        // Make sure that prefix isn't applied to builtin types
+        x: u32,
+        y: MyType,
+    }
+
+    assert_eq!(
+        SuffixedStruct::DECL,
+        indoc! {"
+            export interface SuffixedStructSpecial {
+                x: number;
+                y: MyTypeSpecial;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_suffix = "Special")]
+    enum SuffixedEnum {
+        VariantA(MyType),
+        VariantB(u32),
+    }
+
+    assert_eq!(
+        SuffixedEnum::DECL,
+        indoc! {"
+            export type SuffixedEnumSpecial = { VariantA: MyTypeSpecial } | { VariantB: number };"
+        }
+    );
+}
+
+#[test]
+fn test_prefix_suffix() {
+    type MyType = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Pre", type_suffix = "Suf")]
+    struct DoubleAffixedStruct {
+        // Make sure that prefix isn't applied to builtin types
+        x: u32,
+        y: MyType,
+    }
+
+    assert_eq!(
+        DoubleAffixedStruct::DECL,
+        indoc! {"
+            export interface PreDoubleAffixedStructSuf {
+                x: number;
+                y: PreMyTypeSuf;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Pre", type_suffix = "Suf")]
+    enum DoubleAffixedEnum {
+        VariantA(MyType),
+        VariantB(u32),
+    }
+
+    assert_eq!(
+        DoubleAffixedEnum::DECL,
+        indoc! {"
+            export type PreDoubleAffixedEnumSuf = { VariantA: PreMyTypeSuf } | { VariantB: number };"
+        }
+    );
+}

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -1,17 +1,18 @@
 use serde_derive_internals::{ast, ast::Container as SerdeContainer, attr};
 
-use crate::{attrs::TsifyContainerAttars, ctxt::Ctxt};
+use crate::{attrs::TsifyContainerAttrs, ctxt::Ctxt};
 
 pub struct Container<'a> {
     pub ctxt: Ctxt,
-    pub attrs: TsifyContainerAttars,
+    pub attrs: TsifyContainerAttrs,
     pub serde_container: SerdeContainer<'a>,
+    pub name: String,
 }
 
 impl<'a> Container<'a> {
     pub fn new(serde_container: SerdeContainer<'a>) -> Self {
         let input = &serde_container.original;
-        let attrs = TsifyContainerAttars::from_derive_input(input);
+        let attrs = TsifyContainerAttrs::from_derive_input(input);
         let ctxt = Ctxt::new();
 
         let attrs = match attrs {
@@ -22,10 +23,15 @@ impl<'a> Container<'a> {
             }
         };
 
+        let name = attrs
+            .ty_config
+            .format_name(serde_container.attrs.name().serialize_name());
+
         Self {
             ctxt,
             attrs,
             serde_container,
+            name,
         }
     }
 
@@ -57,7 +63,7 @@ impl<'a> Container<'a> {
     }
 
     pub fn name(&self) -> String {
-        self.serde_attrs().name().serialize_name()
+        self.name.clone()
     }
 
     pub fn generics(&self) -> &syn::Generics {

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -184,7 +184,7 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let type_ann = TsType::from(field.ty);
+        let type_ann = TsType::from_syn_type(&self.container.attrs.ty_config, field.ty);
 
         if let Some(t) = &ts_attrs.type_override {
             let type_ref_names = type_ann.type_ref_names();

--- a/tsify-macros/src/type_alias.rs
+++ b/tsify-macros/src/type_alias.rs
@@ -1,12 +1,12 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{ctxt::Ctxt, decl::TsTypeAliasDecl, typescript::TsType};
+use crate::{attrs::TypeGenerationConfig, ctxt::Ctxt, decl::TsTypeAliasDecl, typescript::TsType};
 
 pub fn expend(item: syn::ItemType) -> syn::Result<TokenStream> {
     let ctxt = Ctxt::new();
 
-    let type_ann = TsType::from(item.ty.as_ref());
+    let type_ann = TsType::from_syn_type(&TypeGenerationConfig::default(), item.ty.as_ref());
 
     let decl = TsTypeAliasDecl {
         id: item.ident.to_string(),


### PR DESCRIPTION
# Motivation

I have a project which is a rust component in a larger typescript codebase. We are using Tsify to create strongly typed bindings to our various methods. However, as we are dealing with similar concepts on both sides, we run into a lot of type name conflicts between exported-rust types and typescript native types. We want to prefix all of the types exported from our rust codebase so that it's clear that the given type is coming from the rust bundle. To facilitate this, without needing to prefix all of actual rust types, we have added two attributes to the tsify macro.

# Attributes

The new attributes are `type_prefix` and `type_suffix` which work recursively.

```rust
#[derive(Tsify)]
#[tsify(type_prefix = "Blah")]
struct SomeType {
    a: u32,
    b: OtherType,
}
```

will generate:

```typescript
interface BlahSomeType {
    a: number;
    b: BlahOtherType;
}
```

We will put this attribute on all of our types and then all of our bindings will use custom types that are prefixed by the given prefix.


# Alternatives

As derive macros can't really have global configuration, this seems like the best way to do this on a global scale. 

We tried using `#[serde(rename = "...")]` combined with `#[tsify(type = "...")]` but it becomes extremely tedious and error prone as soon as you have a lot of nested structs because the `type` annotation does no verification you didn't put the wrong type, and you need to spell out all the components of complex types.

# Comments

The code change is a little large as it passes the configuration through to formerly pure functions, but this perfectly sets us up for things like #26 and other type-gen options.