### PR TITLE
Allow Configuration of Serialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,20 @@ pub use tsify_macros::*;
 #[cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::{JsCast, JsValue};
 
+pub struct SerializationConfig {
+    pub missing_as_null: bool,
+    pub hashmap_as_object: bool,
+}
+
 pub trait Tsify {
     #[cfg(feature = "wasm-bindgen")]
     type JsType: JsCast;
 
     const DECL: &'static str;
+    const SERIALIZATION_CONFIG: SerializationConfig = SerializationConfig {
+        missing_as_null: false,
+        hashmap_as_object: false,
+    };
 
     #[cfg(all(feature = "json", not(feature = "js")))]
     #[inline]
@@ -36,7 +45,11 @@ pub trait Tsify {
     where
         Self: serde::Serialize,
     {
-        serde_wasm_bindgen::to_value(self).map(JsCast::unchecked_from_js)
+        let config = <Self as Tsify>::SERIALIZATION_CONFIG;
+        let serializer = serde_wasm_bindgen::Serializer::new()
+            .serialize_missing_as_null(config.missing_as_null)
+            .serialize_maps_as_objects(config.hashmap_as_object);
+        self.serialize(&serializer).map(JsCast::unchecked_from_js)
     }
 
     #[cfg(feature = "js")]

--- a/tests/affixes.rs
+++ b/tests/affixes.rs
@@ -1,0 +1,116 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_prefix() {
+    type MyType = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Special")]
+    struct PrefixedStruct {
+        // Make sure that prefix isn't applied to builtin types
+        x: u32,
+        y: MyType,
+    }
+
+    assert_eq!(
+        PrefixedStruct::DECL,
+        indoc! {"
+            export interface SpecialPrefixedStruct {
+                x: number;
+                y: SpecialMyType;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Special")]
+    enum PrefixedEnum {
+        VariantA(MyType),
+        VariantB(u32),
+    }
+
+    assert_eq!(
+        PrefixedEnum::DECL,
+        indoc! {"
+            export type SpecialPrefixedEnum = { VariantA: SpecialMyType } | { VariantB: number };"
+        }
+    );
+}
+
+#[test]
+fn test_suffix() {
+    type MyType = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_suffix = "Special")]
+    struct SuffixedStruct {
+        // Make sure that prefix isn't applied to builtin types
+        x: u32,
+        y: MyType,
+    }
+
+    assert_eq!(
+        SuffixedStruct::DECL,
+        indoc! {"
+            export interface SuffixedStructSpecial {
+                x: number;
+                y: MyTypeSpecial;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_suffix = "Special")]
+    enum SuffixedEnum {
+        VariantA(MyType),
+        VariantB(u32),
+    }
+
+    assert_eq!(
+        SuffixedEnum::DECL,
+        indoc! {"
+            export type SuffixedEnumSpecial = { VariantA: MyTypeSpecial } | { VariantB: number };"
+        }
+    );
+}
+
+#[test]
+fn test_prefix_suffix() {
+    type MyType = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Pre", type_suffix = "Suf")]
+    struct DoubleAffixedStruct {
+        // Make sure that prefix isn't applied to builtin types
+        x: u32,
+        y: MyType,
+    }
+
+    assert_eq!(
+        DoubleAffixedStruct::DECL,
+        indoc! {"
+            export interface PreDoubleAffixedStructSuf {
+                x: number;
+                y: PreMyTypeSuf;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Pre", type_suffix = "Suf")]
+    enum DoubleAffixedEnum {
+        VariantA(MyType),
+        VariantB(u32),
+    }
+
+    assert_eq!(
+        DoubleAffixedEnum::DECL,
+        indoc! {"
+            export type PreDoubleAffixedEnumSuf = { VariantA: PreMyTypeSuf } | { VariantB: number };"
+        }
+    );
+}

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -21,6 +21,10 @@ const _: () = {
     impl<'a> Tsify for Borrow<'a> {
         type JsType = JsType;
         const DECL: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+        };
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -22,6 +22,10 @@ const _: () = {
     impl<T, U> Tsify for GenericEnum<T, U> {
         type JsType = JsType;
         const DECL: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+        };
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -19,6 +19,10 @@ const _: () = {
     impl<T> Tsify for GenericStruct<T> {
         type JsType = JsType;
         const DECL: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+        };
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
@@ -89,6 +93,10 @@ const _: () = {
     impl<T> Tsify for GenericNewtype<T> {
         type JsType = JsType;
         const DECL: &'static str = "export type GenericNewtype<T> = T;";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+        };
     }
     #[wasm_bindgen(typescript_custom_section)]
     const TS_APPEND_CONTENT: &'static str = "export type GenericNewtype<T> = T;";

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "js")]
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_transparent() {
+    #[derive(Tsify)]
+    #[tsify(missing_as_null)]
+    struct Optional {
+        a: Option<u32>,
+    }
+
+    assert_eq!(
+        Optional::DECL,
+        indoc! {"
+            export interface Optional {
+                a: number | null;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(hashmap_as_object)]
+    struct MapWrap {
+        a: HashMap<u32, u32>,
+    }
+
+    assert_eq!(
+        MapWrap::DECL,
+        indoc! {"
+            export interface MapWrap {
+                a: Record<number, number>;
+            }"
+        }
+    );
+}

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -1,17 +1,18 @@
 use serde_derive_internals::{ast, ast::Container as SerdeContainer, attr};
 
-use crate::{attrs::TsifyContainerAttars, ctxt::Ctxt};
+use crate::{attrs::TsifyContainerAttrs, ctxt::Ctxt};
 
 pub struct Container<'a> {
     pub ctxt: Ctxt,
-    pub attrs: TsifyContainerAttars,
+    pub attrs: TsifyContainerAttrs,
     pub serde_container: SerdeContainer<'a>,
+    pub name: String,
 }
 
 impl<'a> Container<'a> {
     pub fn new(serde_container: SerdeContainer<'a>) -> Self {
         let input = &serde_container.original;
-        let attrs = TsifyContainerAttars::from_derive_input(input);
+        let attrs = TsifyContainerAttrs::from_derive_input(input);
         let ctxt = Ctxt::new();
 
         let attrs = match attrs {
@@ -22,10 +23,15 @@ impl<'a> Container<'a> {
             }
         };
 
+        let name = attrs
+            .ty_config
+            .format_name(serde_container.attrs.name().serialize_name());
+
         Self {
             ctxt,
             attrs,
             serde_container,
+            name,
         }
     }
 
@@ -57,7 +63,7 @@ impl<'a> Container<'a> {
     }
 
     pub fn name(&self) -> String {
-        self.serde_attrs().name().serialize_name()
+        self.name.clone()
     }
 
     pub fn generics(&self) -> &syn::Generics {

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -119,10 +119,13 @@ impl TsEnumDecl {
                     .map(|t| TsEnumDecl::replace_type_params(t.clone(), type_args))
                     .collect(),
             ),
-            TsType::Option(t) => TsType::Option(Box::new(TsEnumDecl::replace_type_params(
-                t.deref().clone(),
-                type_args,
-            ))),
+            TsType::Option(t, null) => TsType::Option(
+                Box::new(TsEnumDecl::replace_type_params(
+                    t.deref().clone(),
+                    type_args,
+                )),
+                null,
+            ),
             TsType::Fn { params, type_ann } => TsType::Fn {
                 params: params
                     .iter()

--- a/tsify-macros/src/derive.rs
+++ b/tsify-macros/src/derive.rs
@@ -24,6 +24,7 @@ pub fn expand(input: DeriveInput) -> syn::Result<TokenStream> {
                 use tsify::Tsify;
                 impl #impl_generics Tsify for #ident #ty_generics #where_clause {
                     const DECL: &'static str = #decl_str;
+                    const CONFIG: tsify::SerializationConfig;
                 }
             };
         }

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -101,7 +101,7 @@ impl<'a> Parser<'a> {
                 extends
                     .into_iter()
                     .map(|ty| match ty {
-                        TsType::Option(ty) => TsType::Union(vec![*ty, TsType::empty_type_lit()]),
+                        TsType::Option(ty, _) => TsType::Union(vec![*ty, TsType::empty_type_lit()]),
                         _ => ty,
                     })
                     .collect(),
@@ -142,7 +142,9 @@ impl<'a> Parser<'a> {
             Style::Struct => FieldsStyle::Named,
             Style::Newtype => return ParsedFields::Transparent(self.parse_field(&fields[0]).0),
             Style::Tuple => FieldsStyle::Unnamed,
-            Style::Unit => return ParsedFields::Transparent(TsType::nullish()),
+            Style::Unit => {
+                return ParsedFields::Transparent(TsType::nullish(&self.container.attrs.ty_config))
+            }
         };
 
         let fields = fields
@@ -217,7 +219,7 @@ impl<'a> Parser<'a> {
 
                 let type_ann = if optional {
                     match type_ann {
-                        TsType::Option(t) => *t,
+                        TsType::Option(t, _) => *t,
                         _ => type_ann,
                     }
                 } else {
@@ -276,7 +278,7 @@ impl<'a> Parser<'a> {
         let name = variant.attrs.name().serialize_name();
         let style = variant.style;
         let type_ann: TsType = self.parse_fields(style, &variant.fields).into();
-        type_ann.with_tag_type(name, style, tag_type)
+        type_ann.with_tag_type(&self.container.attrs.ty_config, name, style, tag_type)
     }
 }
 

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -184,7 +184,7 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let type_ann = TsType::from(field.ty);
+        let type_ann = TsType::from_syn_type(&self.container.attrs.ty_config, field.ty);
 
         if let Some(t) = &ts_attrs.type_override {
             let type_ref_names = type_ann.type_ref_names();

--- a/tsify-macros/src/type_alias.rs
+++ b/tsify-macros/src/type_alias.rs
@@ -1,12 +1,12 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::{ctxt::Ctxt, decl::TsTypeAliasDecl, typescript::TsType};
+use crate::{attrs::TypeGenerationConfig, ctxt::Ctxt, decl::TsTypeAliasDecl, typescript::TsType};
 
 pub fn expend(item: syn::ItemType) -> syn::Result<TokenStream> {
     let ctxt = Ctxt::new();
 
-    let type_ann = TsType::from(item.ty.as_ref());
+    let type_ann = TsType::from_syn_type(&TypeGenerationConfig::default(), item.ty.as_ref());
 
     let decl = TsTypeAliasDecl {
         id: item.ident.to_string(),

--- a/tsify-macros/src/wasm_bindgen.rs
+++ b/tsify-macros/src/wasm_bindgen.rs
@@ -41,6 +41,9 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     let from_wasm_abi = attrs.from_wasm_abi.then(|| expand_from_wasm_abi(cont));
 
     let typescript_type = decl.id();
+    
+    let missing_as_null = attrs.ty_config.missing_as_null;
+    let hashmap_as_object = attrs.ty_config.hashmap_as_object;
 
     quote! {
         #[automatically_derived]
@@ -63,6 +66,10 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
             impl #impl_generics Tsify for #ident #ty_generics #where_clause {
                 type JsType = JsType;
                 const DECL: &'static str = #decl_str;
+                const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig { 
+                    missing_as_null: #missing_as_null,
+                    hashmap_as_object: #hashmap_as_object,
+                };
             }
 
             #typescript_custom_section


### PR DESCRIPTION
Partially fixes #26. Built off of #28.

This wires up being able to modify the serialization of types in ways that serde_wasm_bindgen supports. We find use for both of these options within our project as the surrounding TS code uses `null` for optional types, as well as always using objects as opposed to Maps.

I've tried to keep the code as contained and reasonable as possible and glad to explain any of the decisions I've made.