### PR TITLE
Allow type overrides at the container level

### DIFF
--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -52,9 +52,21 @@ impl<'a> Parser<'a> {
     }
 
     pub fn parse(&self) -> Decl {
-        match self.container.serde_data() {
-            Data::Struct(style, ref fields) => self.parse_struct(*style, fields),
-            Data::Enum(ref variants) => self.parse_enum(variants),
+        if let Some(decl) = &self.container.attrs.type_override {
+            self.create_type_alias_decl(TsType::Override {
+                type_override: decl.to_string(),
+                type_params: self
+                    .container
+                    .generics()
+                    .type_params()
+                    .map(|p| p.ident.to_string())
+                    .collect(),
+            })
+        } else {
+            match self.container.serde_data() {
+                Data::Struct(style, ref fields) => self.parse_struct(*style, fields),
+                Data::Enum(ref variants) => self.parse_enum(variants),
+            }
         }
     }
 


### PR DESCRIPTION
For types with hand-coded Serialize / Deserialize impls, it can be useful to be able to specify the typescript definition manually. This patch adds a "type" attribute at the container level, similar to the one at field level, and when set produces a type alias for the field instead of the derived struct / enum type.

I am not quite sure if my interpretation of the 'type_params' field  is correct, so please verify. Also, we might want to allow free-form declarations (eg. #[tsify(type = "export interface MyType {...}")]) instead restricting the attribute to type aliasses.
