### PR TITLE
Generate types instead of interfaces

### DIFF
--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -20,10 +20,10 @@ const _: () = {
     }
     impl<'a> Tsify for Borrow<'a> {
         type JsType = JsType;
-        const DECL: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";
+        const DECL: &'static str = "export type Borrow = {\n    raw: string;\n    cow: string;\n};";
     }
     #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";
+    const TS_APPEND_CONTENT: &'static str = "export type Borrow = {\n    raw: string;\n    cow: string;\n};";
     impl<'a> WasmDescribe for Borrow<'a> {
         #[inline]
         fn describe() {

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -18,10 +18,10 @@ const _: () = {
     }
     impl<T> Tsify for GenericStruct<T> {
         type JsType = JsType;
-        const DECL: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
+        const DECL: &'static str = "export type GenericStruct<T> = {\n    x: T;\n};";
     }
     #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
+    const TS_APPEND_CONTENT: &'static str = "export type GenericStruct<T> = {\n    x: T;\n};";
     impl<T> WasmDescribe for GenericStruct<T> {
         #[inline]
         fn describe() {

--- a/tests/flatten.rs
+++ b/tests/flatten.rs
@@ -22,9 +22,9 @@ fn test_flatten() {
     assert_eq!(
         B::DECL,
         indoc! {"
-            export interface B extends A {
+            export type B = {
                 c: number;
-            }"
+            } & A;"
         }
     );
 }
@@ -50,4 +50,30 @@ fn test_flatten_option() {
             export type B = { c: number } & (A | {});"
         }
     );
+}
+
+#[test]
+fn test_flatten_enum() {
+    #[derive(Tsify)]
+    #[serde(tag = "type")]
+    enum A {
+        A,
+        B { b_data: String },
+    }
+
+    #[derive(Tsify)]
+    struct B {
+        #[serde(flatten)]
+        a: A,
+        b: i32,
+    }
+
+    assert_eq!(
+        B::DECL,
+        indoc! {"
+            export type B = {
+                b: number;
+            } & A;"
+        }
+    )
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -18,11 +18,11 @@ fn test_generic_struct() {
     assert_eq!(
         GenericStruct::<(), (), (), ()>::DECL,
         indoc! {"
-            export interface GenericStruct<A, B, D> {
+            export type GenericStruct<A, B, D> = {
                 a: A;
                 b: B;
                 d: D;
-            }"
+            };"
         }
     );
 

--- a/tests/optional.rs
+++ b/tests/optional.rs
@@ -30,44 +30,44 @@ fn test_optional() {
         assert_eq!(
             Optional::DECL,
             indoc! {"
-            export interface Optional {
+            export type Optional = {
                 a?: number;
                 b?: string;
                 c?: number;
                 d?: string | undefined;
-            }"
+            };"
             }
         );
         assert_eq!(
             OptionalAll::DECL,
             indoc! {"
-                export interface OptionalAll {
+                export type OptionalAll = {
                     a?: number;
                     b?: number;
                     c?: number | undefined;
-                }"
+                };"
             }
         );
     } else {
         assert_eq!(
             Optional::DECL,
             indoc! {"
-                export interface Optional {
+                export type Optional = {
                     a?: number;
                     b?: string;
                     c?: number;
                     d?: string | null;
-                }"
+                };"
             }
         );
         assert_eq!(
             OptionalAll::DECL,
             indoc! {"
-                export interface OptionalAll {
+                export type OptionalAll = {
                     a?: number;
                     b?: number;
                     c?: number | null;
-                }"
+                };"
             }
         );
     }

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -17,10 +17,10 @@ fn test_rename() {
     assert_eq!(
         RenamedStruct::DECL,
         indoc! {"
-            export interface RenamedStruct {
+            export type RenamedStruct = {
                 X: number;
                 Y: number;
-            }"
+            };"
         }
     );
 
@@ -102,20 +102,20 @@ fn test_rename_all() {
     assert_eq!(
         PascalCase::DECL,
         indoc! {"
-            export interface PascalCase {
+            export type PascalCase = {
                 Foo: boolean;
                 FooBar: boolean;
-            }"
+            };"
         }
     );
 
     assert_eq!(
         ScreamingKebab::DECL,
         indoc! {r#"
-            export interface ScreamingKebab {
+            export type ScreamingKebab = {
                 FOO: boolean;
                 "FOO-BAR": boolean;
-            }"#
+            };"#
         }
     );
 }

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -20,9 +20,9 @@ fn test_skip() {
     assert_eq!(
         Struct::DECL,
         indoc! {"
-            export interface Struct {
+            export type Struct = {
                 a: number;
-            }"
+            };"
         }
     );
 

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -28,17 +28,17 @@ fn test_named_fields() {
 
     let expected = if cfg!(feature = "js") {
         indoc! {"
-            export interface A {
+            export type A = {
                 a: [number, number];
                 b: Map<string, bigint>;
-            }"
+            };"
         }
     } else {
         indoc! {"
-            export interface A {
+            export type A = {
                 a: [number, number];
                 b: Record<string, number>;
-            }"
+            };"
         }
     };
 
@@ -79,9 +79,9 @@ fn test_nested_struct() {
     assert_eq!(
         B::DECL,
         indoc! {"
-            export interface B {
+            export type B = {
                 a: A;
-            }"
+            };"
         }
     );
 }
@@ -99,10 +99,10 @@ fn test_struct_with_borrowed_fields() {
     assert_eq!(
         Borrow::DECL,
         indoc! {"
-            export interface Borrow {
+            export type Borrow = {
                 raw: string;
                 cow: string;
-            }"
+            };"
         }
     );
 }
@@ -119,11 +119,11 @@ fn test_tagged_struct() {
     assert_eq!(
         TaggedStruct::DECL,
         indoc! {r#"
-            export interface TaggedStruct {
+            export type TaggedStruct = {
                 type: "TaggedStruct";
                 x: number;
                 y: number;
-            }"#
+            };"#
         }
     );
 }

--- a/tests/type_override.rs
+++ b/tests/type_override.rs
@@ -23,11 +23,11 @@ fn test_struct_with_type_override() {
     assert_eq!(
         Struct::DECL,
         indoc! {r#"
-            export interface Struct {
+            export type Struct = {
                 a: number;
                 b: 0 | 1 | 2;
                 c: string | null;
-            }"#
+            };"#
         }
     );
 
@@ -67,9 +67,9 @@ fn test_generic_struct_with_type_override() {
     }
 
     let expected = indoc! {r#"
-        export interface Foo<T> {
+        export type Foo<T> = {
             bar: [T, ...T[]];
-        }"#
+        };"#
     };
 
     assert_eq!(Foo::<()>::DECL, expected);

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -36,26 +36,17 @@ pub struct TsInterfaceDecl {
 
 impl Display for TsInterfaceDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "export interface {}", self.id)?;
+        write!(f, "export type {}", self.id)?;
 
         if !self.type_params.is_empty() {
             let type_params = self.type_params.join(", ");
             write!(f, "<{type_params}>")?;
         }
 
-        if !self.extends.is_empty() {
-            let extends = self
-                .extends
-                .iter()
-                .map(|ty| ty.to_string())
-                .collect::<Vec<_>>()
-                .join(", ");
-
-            write!(f, " extends {extends}")?;
-        }
+        write!(f, " =")?;
 
         if self.body.is_empty() {
-            write!(f, " {{}}")
+            write!(f, " {{}}")?;
         } else {
             let members = self
                 .body
@@ -64,8 +55,18 @@ impl Display for TsInterfaceDecl {
                 .collect::<Vec<_>>()
                 .join("");
 
-            write!(f, " {{{members}\n}}")
+            write!(f, " {{{members}\n}}")?;
         }
+
+        if !self.extends.is_empty() {
+            self
+                .extends
+                .iter()
+                .map(|ty| write!(f, " & {ty}"))
+                .collect::<std::fmt::Result>()?;
+        }
+
+        write!(f, ";")
     }
 }
 


### PR DESCRIPTION
Types are more flexible. Interfaces cause the crate to generate invalid typescript by attempting to extend a type in some cases, like when flattening a tagged enum into a struct.