### PR TITLE
Ensure type names ignore serde rename when exporting

### DIFF
--- a/tests/reference_rename.rs
+++ b/tests/reference_rename.rs
@@ -1,0 +1,36 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_reference_rename() {
+    #[derive(Tsify)]
+    #[serde(rename = "foo")]
+    pub struct Foo {
+        x: i32,
+    }
+
+    #[derive(Tsify)]
+    pub struct Bar {
+        foo: Foo,
+    }
+
+    assert_eq!(
+        Bar::DECL,
+        indoc! {"
+            export interface Bar {
+                foo: Foo;
+            }"
+        }
+    );
+    assert_eq!(
+        Foo::DECL,
+        indoc! {"
+            export interface Foo {
+                x: number;
+            }"
+        }
+    );
+}

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -47,6 +47,10 @@ impl<'a> Container<'a> {
         &self.serde_container.ident
     }
 
+    pub fn ident_str(&self) -> String {
+        self.ident().to_string()
+    }
+
     #[inline]
     pub fn serde_attrs(&self) -> &attr::Container {
         &self.serde_container.attrs

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 
 use crate::typescript::{TsType, TsTypeElement, TsTypeLit};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TsTypeAliasDecl {
     pub id: String,
     pub export: bool,
@@ -27,6 +27,7 @@ impl Display for TsTypeAliasDecl {
     }
 }
 
+#[derive(Debug)]
 pub struct TsInterfaceDecl {
     pub id: String,
     pub type_params: Vec<String>,
@@ -69,6 +70,7 @@ impl Display for TsInterfaceDecl {
     }
 }
 
+#[derive(Debug)]
 pub struct TsEnumDecl {
     pub id: String,
     pub type_params: Vec<String>,

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -70,7 +70,7 @@ impl<'a> Parser<'a> {
 
     fn create_type_alias_decl(&self, type_ann: TsType) -> Decl {
         Decl::TsTypeAlias(TsTypeAliasDecl {
-            id: self.container.name(),
+            id: self.container.ident_str(),
             export: true,
             type_params: self.create_relevant_type_params(type_ann.type_ref_names()),
             type_ann,
@@ -91,7 +91,7 @@ impl<'a> Parser<'a> {
             let type_params = self.create_relevant_type_params(type_ref_names);
 
             Decl::TsInterface(TsInterfaceDecl {
-                id: self.container.name(),
+                id: self.container.ident_str(),
                 type_params,
                 extends,
                 body: members,
@@ -264,7 +264,7 @@ impl<'a> Parser<'a> {
         let relevant_type_params = self.create_relevant_type_params(type_ref_names);
 
         Decl::TsEnum(TsEnumDecl {
-            id: self.container.name(),
+            id: self.container.ident_str(),
             type_params: relevant_type_params,
             members,
             namespace: self.container.attrs.namespace,


### PR DESCRIPTION
Addresses issue #43 where references to containers that used `serde(rename = ...)` would use the original name but the type declaration used the "rename" name. Now the behavior is that the type declaration always uses the original name.

Fixes #43