### PR TITLE
Add a 'quote' attribute to generate quoted TS properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Tsify field attributes
 
 - `type`
 - `optional`
+- `quote`
 
 Serde attributes
 
@@ -138,6 +139,27 @@ export interface Optional {
   a?: number;
   b?: string;
   c?: number;
+}
+```
+
+## Quoted Properties
+
+`#[tsify(quote)]` puts the resulting TypeScript property in quotes. This can be useful if, for example, `#[serde(rename)]` results in a property that is not a valid identifier in TypeScript.
+
+```rust
+#[derive(Tsify)]
+struct Quoted {
+  #[serde(rename = "with spaces")]
+  #[tsify(quote)]
+  with_spaces: i32
+}
+```
+
+Generated type:
+
+```ts
+export interface Quoted {
+  "with spaces": number;
 }
 ```
 

--- a/tests/quote.rs
+++ b/tests/quote.rs
@@ -12,6 +12,10 @@ fn test_quote() {
         #[tsify(quote)]
         with_spaces: i32,
 
+        #[serde(rename = "with-hyphen")]
+        #[tsify(quote)]
+        with_hyphen: i32,
+
         #[serde(rename = "@invalid!ident")]
         #[tsify(quote)]
         invalid_ident: i32,
@@ -22,6 +26,7 @@ fn test_quote() {
         indoc! { r#"
             export interface QuotedStruct {
                 "with spaces": number;
+                "with-hyphen": number;
                 "@invalid!ident": number;
             }"#
         }

--- a/tests/quote.rs
+++ b/tests/quote.rs
@@ -1,0 +1,29 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_quote() {
+    #[derive(Tsify)]
+    struct QuotedStruct {
+        #[serde(rename = "with spaces")]
+        #[tsify(quote)]
+        with_spaces: i32,
+
+        #[serde(rename = "@invalid!ident")]
+        #[tsify(quote)]
+        invalid_ident: i32,
+    }
+
+    assert_eq!(
+        QuotedStruct::DECL,
+        indoc! { r#"
+            export interface QuotedStruct {
+                "with spaces": number;
+                "@invalid!ident": number;
+            }"#
+        }
+    );
+}

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -60,6 +60,7 @@ impl TsifyContainerAttars {
 pub struct TsifyFieldAttrs {
     pub type_override: Option<String>,
     pub optional: bool,
+    pub quote: bool,
 }
 
 impl TsifyFieldAttrs {
@@ -67,6 +68,7 @@ impl TsifyFieldAttrs {
         let mut attrs = Self {
             type_override: None,
             optional: false,
+            quote: false,
         };
 
         for attr in &field.original.attrs {
@@ -89,6 +91,14 @@ impl TsifyFieldAttrs {
                         return Err(meta.error("duplicate attribute"));
                     }
                     attrs.optional = true;
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("quote") {
+                    if attrs.quote {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    attrs.quote = true;
                     return Ok(());
                 }
 

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -211,9 +211,12 @@ impl<'a> Parser<'a> {
                 let key = field.attrs.name().serialize_name();
                 let (type_ann, field_attrs) = self.parse_field(field);
 
-                let optional = field_attrs.map_or(false, |attrs| attrs.optional);
+                let (optional, quote) =
+                    field_attrs.map_or((false, false), |attrs| (attrs.optional, attrs.quote));
                 let default_is_none = self.container.serde_attrs().default().is_none()
                     && field.attrs.default().is_none();
+
+                let key = if quote { format!("\"{}\"", key) } else { key };
 
                 let type_ann = if optional {
                     match type_ann {

--- a/tsify-macros/src/typescript.rs
+++ b/tsify-macros/src/typescript.rs
@@ -578,6 +578,10 @@ fn is_js_ident(string: &str) -> bool {
     !string.contains('-')
 }
 
+fn is_quoted(string: &str) -> bool {
+    string.starts_with('"') && string.ends_with('"')
+}
+
 impl Display for TsTypeElement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let key = &self.key;
@@ -585,7 +589,7 @@ impl Display for TsTypeElement {
 
         let optional_ann = if self.optional { "?" } else { "" };
 
-        if is_js_ident(key) {
+        if is_js_ident(key) || is_quoted(key) {
             write!(f, "{key}{optional_ann}: {type_ann}")
         } else {
             write!(f, "\"{key}\"{optional_ann}: {type_ann}")


### PR DESCRIPTION
In TypeScript it is possible to have interfaces with fields that are not valid JS identifiers, if they are enclosed in quotes. If you use the current version of tsify with `#[serde(rename)]`, it can produce interfaces with these properties, but in most cases it does not enclose them with quotes (unless they contain a `-`, with current logic).

One approach to fixing this is to enhance the logic for automatically detecting whether a property is a valid JS identifier. Since this is defined with a [relatively large](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#identifiers) [category](https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5Cp%7BXID_Start%7D&g=&i=) of Unicode characters, the easiest way to do this would be to take a dependency on a crate such as [unicode-ident](https://docs.rs/unicode-ident/1.0.12/unicode_ident/).

I figured a simpler way was to give the crate user an escape hatch in the form of a new attribute `quote` which will enclose the resulting TS field in quotes.

Closes #37 