### PR TITLE
fix: remove trait bounds from where clause in `IntoWasmAbi` expansion

### DIFF
--- a/tests/expand/generic_constrained_struct.expanded.rs
+++ b/tests/expand/generic_constrained_struct.expanded.rs
@@ -1,0 +1,498 @@
+use tsify::Tsify;
+pub trait Constraint {}
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct GenericStruct<T: Constraint> {
+    x: T,
+}
+const _: () = {
+    extern crate serde as _serde;
+    use tsify::Tsify;
+    use wasm_bindgen::{
+        convert::{
+            FromWasmAbi, VectorFromWasmAbi, IntoWasmAbi, VectorIntoWasmAbi,
+            OptionFromWasmAbi, OptionIntoWasmAbi, RefFromWasmAbi,
+        },
+        describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
+    };
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(typescript_type = "GenericStruct")]
+        pub type JsType;
+    }
+    #[automatically_derived]
+    impl<T: Constraint> Tsify for GenericStruct<T> {
+        type JsType = JsType;
+        const DECL: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+            large_number_types_as_bigints: false,
+        };
+    }
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_APPEND_CONTENT: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
+    #[automatically_derived]
+    impl<T: Constraint> WasmDescribe for GenericStruct<T> {
+        #[inline]
+        fn describe() {
+            <Self as Tsify>::JsType::describe()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> WasmDescribeVector for GenericStruct<T> {
+        #[inline]
+        fn describe_vector() {
+            <Self as Tsify>::JsType::describe_vector()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> IntoWasmAbi for &GenericStruct<T>
+    where
+        GenericStruct<T>: _serde::Serialize,
+    {
+        type Abi = <JsType as IntoWasmAbi>::Abi;
+        #[inline]
+        fn into_abi(self) -> Self::Abi {
+            match self.into_js() {
+                Ok(js) => js.into_abi(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = ::alloc::__export::must_use({
+                        ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        )
+                    });
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> IntoWasmAbi for GenericStruct<T>
+    where
+        GenericStruct<T>: _serde::Serialize,
+    {
+        type Abi = <JsType as IntoWasmAbi>::Abi;
+        #[inline]
+        fn into_abi(self) -> Self::Abi {
+            (&self).into_abi()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> OptionIntoWasmAbi for GenericStruct<T>
+    where
+        GenericStruct<T>: _serde::Serialize,
+    {
+        #[inline]
+        fn none() -> Self::Abi {
+            <JsType as OptionIntoWasmAbi>::none()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> From<GenericStruct<T>> for JsValue
+    where
+        GenericStruct<T>: _serde::Serialize,
+    {
+        #[inline]
+        fn from(value: GenericStruct<T>) -> Self {
+            match value.into_js() {
+                Ok(js) => js.into(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = ::alloc::__export::must_use({
+                        ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        )
+                    });
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> VectorIntoWasmAbi for GenericStruct<T>
+    where
+        GenericStruct<T>: _serde::Serialize,
+    {
+        type Abi = <JsType as VectorIntoWasmAbi>::Abi;
+        #[inline]
+        fn vector_into_abi(vector: Box<[Self]>) -> Self::Abi {
+            let values = vector
+                .iter()
+                .map(|value| match value.into_js() {
+                    Ok(js) => js.into(),
+                    Err(err) => {
+                        let loc = core::panic::Location::caller();
+                        let msg = ::alloc::__export::must_use({
+                            ::alloc::fmt::format(
+                                format_args!(
+                                    "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                    .file(), loc.line(), loc.column(),
+                                ),
+                            )
+                        });
+                        {
+                            #[cold]
+                            #[track_caller]
+                            #[inline(never)]
+                            #[rustc_const_panic_str]
+                            #[rustc_do_not_const_check]
+                            const fn panic_cold_display<T: ::core::fmt::Display>(
+                                arg: &T,
+                            ) -> ! {
+                                ::core::panicking::panic_display(arg)
+                            }
+                            panic_cold_display(&msg);
+                        };
+                    }
+                })
+                .collect();
+            JsValue::vector_into_abi(values)
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> FromWasmAbi for GenericStruct<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as FromWasmAbi>::Abi;
+        #[inline]
+        unsafe fn from_abi(js: Self::Abi) -> Self {
+            let result = Self::from_js(&JsType::from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            result.unwrap_throw()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> OptionFromWasmAbi for GenericStruct<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        #[inline]
+        fn is_none(js: &Self::Abi) -> bool {
+            <JsType as OptionFromWasmAbi>::is_none(js)
+        }
+    }
+    pub struct SelfOwner<T>(T);
+    #[automatically_derived]
+    impl<T> ::core::ops::Deref for SelfOwner<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> RefFromWasmAbi for GenericStruct<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as RefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            let result = Self::from_js(&*JsType::ref_from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            SelfOwner(result.unwrap_throw())
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> VectorFromWasmAbi for GenericStruct<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as VectorFromWasmAbi>::Abi;
+        #[inline]
+        unsafe fn vector_from_abi(js: Self::Abi) -> Box<[Self]> {
+            JsValue::vector_from_abi(js)
+                .into_iter()
+                .map(|value| {
+                    let result = Self::from_js(value);
+                    if let Err(err) = result {
+                        wasm_bindgen::throw_str(err.to_string().as_ref());
+                    }
+                    result.unwrap_throw()
+                })
+                .collect()
+        }
+    }
+};
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct GenericNewtype<T: Constraint>(T);
+const _: () = {
+    extern crate serde as _serde;
+    use tsify::Tsify;
+    use wasm_bindgen::{
+        convert::{
+            FromWasmAbi, VectorFromWasmAbi, IntoWasmAbi, VectorIntoWasmAbi,
+            OptionFromWasmAbi, OptionIntoWasmAbi, RefFromWasmAbi,
+        },
+        describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
+    };
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(typescript_type = "GenericNewtype")]
+        pub type JsType;
+    }
+    #[automatically_derived]
+    impl<T: Constraint> Tsify for GenericNewtype<T> {
+        type JsType = JsType;
+        const DECL: &'static str = "export type GenericNewtype<T> = T;";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+            large_number_types_as_bigints: false,
+        };
+    }
+    #[wasm_bindgen(typescript_custom_section)]
+    const TS_APPEND_CONTENT: &'static str = "export type GenericNewtype<T> = T;";
+    #[automatically_derived]
+    impl<T: Constraint> WasmDescribe for GenericNewtype<T> {
+        #[inline]
+        fn describe() {
+            <Self as Tsify>::JsType::describe()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> WasmDescribeVector for GenericNewtype<T> {
+        #[inline]
+        fn describe_vector() {
+            <Self as Tsify>::JsType::describe_vector()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> IntoWasmAbi for &GenericNewtype<T>
+    where
+        GenericNewtype<T>: _serde::Serialize,
+    {
+        type Abi = <JsType as IntoWasmAbi>::Abi;
+        #[inline]
+        fn into_abi(self) -> Self::Abi {
+            match self.into_js() {
+                Ok(js) => js.into_abi(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = ::alloc::__export::must_use({
+                        ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        )
+                    });
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> IntoWasmAbi for GenericNewtype<T>
+    where
+        GenericNewtype<T>: _serde::Serialize,
+    {
+        type Abi = <JsType as IntoWasmAbi>::Abi;
+        #[inline]
+        fn into_abi(self) -> Self::Abi {
+            (&self).into_abi()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> OptionIntoWasmAbi for GenericNewtype<T>
+    where
+        GenericNewtype<T>: _serde::Serialize,
+    {
+        #[inline]
+        fn none() -> Self::Abi {
+            <JsType as OptionIntoWasmAbi>::none()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> From<GenericNewtype<T>> for JsValue
+    where
+        GenericNewtype<T>: _serde::Serialize,
+    {
+        #[inline]
+        fn from(value: GenericNewtype<T>) -> Self {
+            match value.into_js() {
+                Ok(js) => js.into(),
+                Err(err) => {
+                    let loc = core::panic::Location::caller();
+                    let msg = ::alloc::__export::must_use({
+                        ::alloc::fmt::format(
+                            format_args!(
+                                "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                .file(), loc.line(), loc.column(),
+                            ),
+                        )
+                    });
+                    {
+                        #[cold]
+                        #[track_caller]
+                        #[inline(never)]
+                        #[rustc_const_panic_str]
+                        #[rustc_do_not_const_check]
+                        const fn panic_cold_display<T: ::core::fmt::Display>(
+                            arg: &T,
+                        ) -> ! {
+                            ::core::panicking::panic_display(arg)
+                        }
+                        panic_cold_display(&msg);
+                    };
+                }
+            }
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> VectorIntoWasmAbi for GenericNewtype<T>
+    where
+        GenericNewtype<T>: _serde::Serialize,
+    {
+        type Abi = <JsType as VectorIntoWasmAbi>::Abi;
+        #[inline]
+        fn vector_into_abi(vector: Box<[Self]>) -> Self::Abi {
+            let values = vector
+                .iter()
+                .map(|value| match value.into_js() {
+                    Ok(js) => js.into(),
+                    Err(err) => {
+                        let loc = core::panic::Location::caller();
+                        let msg = ::alloc::__export::must_use({
+                            ::alloc::fmt::format(
+                                format_args!(
+                                    "(Converting type failed) {0} ({1}:{2}:{3})", err, loc
+                                    .file(), loc.line(), loc.column(),
+                                ),
+                            )
+                        });
+                        {
+                            #[cold]
+                            #[track_caller]
+                            #[inline(never)]
+                            #[rustc_const_panic_str]
+                            #[rustc_do_not_const_check]
+                            const fn panic_cold_display<T: ::core::fmt::Display>(
+                                arg: &T,
+                            ) -> ! {
+                                ::core::panicking::panic_display(arg)
+                            }
+                            panic_cold_display(&msg);
+                        };
+                    }
+                })
+                .collect();
+            JsValue::vector_into_abi(values)
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> FromWasmAbi for GenericNewtype<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as FromWasmAbi>::Abi;
+        #[inline]
+        unsafe fn from_abi(js: Self::Abi) -> Self {
+            let result = Self::from_js(&JsType::from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            result.unwrap_throw()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> OptionFromWasmAbi for GenericNewtype<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        #[inline]
+        fn is_none(js: &Self::Abi) -> bool {
+            <JsType as OptionFromWasmAbi>::is_none(js)
+        }
+    }
+    pub struct SelfOwner<T>(T);
+    #[automatically_derived]
+    impl<T> ::core::ops::Deref for SelfOwner<T> {
+        type Target = T;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> RefFromWasmAbi for GenericNewtype<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as RefFromWasmAbi>::Abi;
+        type Anchor = SelfOwner<Self>;
+        unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+            let result = Self::from_js(&*JsType::ref_from_abi(js));
+            if let Err(err) = result {
+                wasm_bindgen::throw_str(err.to_string().as_ref());
+            }
+            SelfOwner(result.unwrap_throw())
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> VectorFromWasmAbi for GenericNewtype<T>
+    where
+        Self: _serde::de::DeserializeOwned,
+    {
+        type Abi = <JsType as VectorFromWasmAbi>::Abi;
+        #[inline]
+        unsafe fn vector_from_abi(js: Self::Abi) -> Box<[Self]> {
+            JsValue::vector_from_abi(js)
+                .into_iter()
+                .map(|value| {
+                    let result = Self::from_js(value);
+                    if let Err(err) = result {
+                        wasm_bindgen::throw_str(err.to_string().as_ref());
+                    }
+                    result.unwrap_throw()
+                })
+                .collect()
+        }
+    }
+};

--- a/tests/expand/generic_constrained_struct.rs
+++ b/tests/expand/generic_constrained_struct.rs
@@ -1,0 +1,13 @@
+use tsify::Tsify;
+
+pub trait Constraint {}
+
+#[derive(Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct GenericStruct<T: Constraint> {
+    x: T,
+}
+
+#[derive(Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct GenericNewtype<T: Constraint>(T);

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -1,5 +1,4 @@
 use serde_derive_internals::{ast, ast::Container as SerdeContainer, attr};
-use syn::punctuated::Punctuated;
 
 use crate::{attrs::TsifyContainerAttrs, error_tracker::ErrorTracker};
 
@@ -106,30 +105,6 @@ impl<'a> Container<'a> {
                     syn::GenericParam::Type(param) => syn::GenericParam::Type(syn::TypeParam {
                         eq_token: None,
                         default: None,
-                        ..param.clone()
-                    }),
-                    _ => param.clone(),
-                })
-                .collect(),
-            ..generics.clone()
-        }
-    }
-
-    /// Remove the default from every type parameter because in the generated impls
-    /// they look like associated types: "error: associated type bindings are not
-    /// allowed here".
-    pub fn generics_without_defaults_or_bounds(&self) -> syn::Generics {
-        let generics = self.generics();
-        syn::Generics {
-            params: generics
-                .params
-                .iter()
-                .map(|param| match param {
-                    syn::GenericParam::Type(param) => syn::GenericParam::Type(syn::TypeParam {
-                        eq_token: None,
-                        default: None,
-                        colon_token: None,
-                        bounds: Punctuated::new(),
                         ..param.clone()
                     }),
                     _ => param.clone(),

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -1,4 +1,5 @@
 use serde_derive_internals::{ast, ast::Container as SerdeContainer, attr};
+use syn::punctuated::Punctuated;
 
 use crate::{attrs::TsifyContainerAttrs, error_tracker::ErrorTracker};
 
@@ -105,6 +106,30 @@ impl<'a> Container<'a> {
                     syn::GenericParam::Type(param) => syn::GenericParam::Type(syn::TypeParam {
                         eq_token: None,
                         default: None,
+                        ..param.clone()
+                    }),
+                    _ => param.clone(),
+                })
+                .collect(),
+            ..generics.clone()
+        }
+    }
+
+    /// Remove the default from every type parameter because in the generated impls
+    /// they look like associated types: "error: associated type bindings are not
+    /// allowed here".
+    pub fn generics_without_defaults_or_bounds(&self) -> syn::Generics {
+        let generics = self.generics();
+        syn::Generics {
+            params: generics
+                .params
+                .iter()
+                .map(|param| match param {
+                    syn::GenericParam::Type(param) => syn::GenericParam::Type(syn::TypeParam {
+                        eq_token: None,
+                        default: None,
+                        colon_token: None,
+                        bounds: Punctuated::new(),
                         ..param.clone()
                     }),
                     _ => param.clone(),

--- a/tsify-macros/src/wasm_bindgen.rs
+++ b/tsify-macros/src/wasm_bindgen.rs
@@ -97,12 +97,13 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
     let ident = cont.ident();
     let serde_path = cont.serde_container.attrs.serde_path();
     let mut generics = cont.generics_without_defaults();
-    let borrowed_generics = generics.clone();
+
+    let generics_without_bounds = cont.generics_without_defaults_or_bounds();
 
     generics
         .make_where_clause()
         .predicates
-        .push(parse_quote!(#ident #borrowed_generics: #serde_path::Serialize));
+        .push(parse_quote!(#ident #generics_without_bounds: #serde_path::Serialize));
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 


### PR DESCRIPTION
This PR fixes an issue with trait implementation where you have

```rust
use tsify::Tsify;

pub trait Constraint {}

#[derive(Tsify)]
#[tsify(into_wasm_abi, from_wasm_abi)]
pub struct GenericStruct<T: Constraint> {
    x: T,
}
```

```console
error[E0229]: associated item constraints are not allowed here
  |
  | pub struct GenericStruct<T: Constraint> {
  |                          ^^^^^^^^^^^^^ associated item constraint not allowed here
```

This is because the implementation of traits would have an invalidate generic constraint in the where clause:
```rust
    #[automatically_derived]
    impl<T: Constraint> IntoWasmAbi for &GenericStruct<T>
    where
        GenericStruct<T: Constraint>: _serde::Serialize,
```

This has been fixed:

```rust
    #[automatically_derived]
    impl<T: Constraint> IntoWasmAbi for &GenericStruct<T>
    where
        GenericStruct<T>: _serde::Serialize,
```