### PR TITLE
Allow `type_alias` argument to prefer them over interfaces

### DIFF
--- a/tests/affixes.rs
+++ b/tests/affixes.rs
@@ -36,7 +36,11 @@ fn test_prefix() {
     assert_eq!(
         PrefixedEnum::DECL,
         indoc! {"
-            export type SpecialPrefixedEnum = { VariantA: SpecialMyType } | { VariantB: number };"
+            export type SpecialPrefixedEnum = {
+                VariantA: SpecialMyType;
+            } | {
+                VariantB: number;
+            };"
         }
     );
 }
@@ -73,7 +77,11 @@ fn test_suffix() {
     assert_eq!(
         SuffixedEnum::DECL,
         indoc! {"
-            export type SuffixedEnumSpecial = { VariantA: MyTypeSpecial } | { VariantB: number };"
+            export type SuffixedEnumSpecial = {
+                VariantA: MyTypeSpecial;
+            } | {
+                VariantB: number;
+            };"
         }
     );
 }
@@ -110,7 +118,11 @@ fn test_prefix_suffix() {
     assert_eq!(
         DoubleAffixedEnum::DECL,
         indoc! {"
-            export type PreDoubleAffixedEnumSuf = { VariantA: PreMyTypeSuf } | { VariantB: number };"
+            export type PreDoubleAffixedEnumSuf = {
+                VariantA: PreMyTypeSuf;
+            } | {
+                VariantB: number;
+            };"
         }
     );
 }

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -32,7 +32,20 @@ fn test_externally_tagged_enum() {
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = {
+            Struct: {
+                x: string;
+                y: number;
+            };
+        } | {
+            EmptyStruct: {};
+        } | {
+            Tuple: [number, string];
+        } | {
+            EmptyTuple: [];
+        } | {
+            Newtype: Foo;
+        } | "Unit";"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -79,23 +92,36 @@ fn test_externally_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { x: string; y: number } };
+            export type Struct = {
+                Struct: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { EmptyStruct: {} };
+            export type EmptyStruct = {
+                EmptyStruct: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = {
+                Tuple: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { EmptyTuple: [] };
+            export type EmptyTuple = {
+                EmptyTuple: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __ExternalFoo };
+            export type Newtype = {
+                Newtype: __ExternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -105,7 +131,20 @@ fn test_externally_tagged_enum_with_namespace() {
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = {
+            Struct: {
+                x: string;
+                y: number;
+            };
+        } | {
+            EmptyStruct: {};
+        } | {
+            Tuple: [number, string];
+        } | {
+            EmptyTuple: [];
+        } | {
+            Newtype: Foo;
+        } | "Unit";"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -131,7 +170,17 @@ fn test_internally_tagged_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = {
+            t: "Struct";
+            x: string;
+            y: number;
+        } | {
+            t: "EmptyStruct";
+        } | ({
+            t: "Newtype";
+        } & Foo) | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -163,25 +212,45 @@ fn test_internally_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: "Struct"; x: string; y: number };
+            export type Struct = {
+                t: "Struct";
+                x: string;
+                y: number;
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: "EmptyStruct" };
+            export type EmptyStruct = {
+                t: "EmptyStruct";
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: "Newtype" } & __InternalFoo;
+            export type Newtype = {
+                t: "Newtype";
+            } & __InternalFoo;
             /**
              * Comment for Unit
              */
-            export type Unit = { t: "Unit" };
+            export type Unit = {
+                t: "Unit";
+            };
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = {
+            t: "Struct";
+            x: string;
+            y: number;
+        } | {
+            t: "EmptyStruct";
+        } | ({
+            t: "Newtype";
+        } & Foo) | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -211,7 +280,27 @@ fn test_adjacently_tagged_enum() {
         /**
          * Comment for Adjacent
          */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+        export type Adjacent = {
+            t: "Struct";
+            c: {
+                x: string;
+                y: number;
+            };
+        } | {
+            t: "EmptyStruct";
+            c: {};
+        } | {
+            t: "Tuple";
+            c: [number, string];
+        } | {
+            t: "EmptyTuple";
+            c: [];
+        } | {
+            t: "Newtype";
+            c: Foo;
+        } | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Adjacent::DECL, expected);
@@ -247,33 +336,73 @@ fn test_adjacently_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: "Struct"; c: { x: string; y: number } };
+            export type Struct = {
+                t: "Struct";
+                c: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: "EmptyStruct"; c: {} };
+            export type EmptyStruct = {
+                t: "EmptyStruct";
+                c: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { t: "Tuple"; c: [number, string] };
+            export type Tuple = {
+                t: "Tuple";
+                c: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { t: "EmptyTuple"; c: [] };
+            export type EmptyTuple = {
+                t: "EmptyTuple";
+                c: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: "Newtype"; c: __AdjacentFoo };
+            export type Newtype = {
+                t: "Newtype";
+                c: __AdjacentFoo;
+            };
             /**
              * Comment for Unit
              */
-            export type Unit = { t: "Unit" };
+            export type Unit = {
+                t: "Unit";
+            };
         }
 
         /**
          * Comment for Adjacent
          */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+        export type Adjacent = {
+            t: "Struct";
+            c: {
+                x: string;
+                y: number;
+            };
+        } | {
+            t: "EmptyStruct";
+            c: {};
+        } | {
+            t: "Tuple";
+            c: [number, string];
+        } | {
+            t: "EmptyTuple";
+            c: [];
+        } | {
+            t: "Newtype";
+            c: Foo;
+        } | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Adjacent::DECL, expected);
@@ -304,14 +433,20 @@ fn test_untagged_enum() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | undefined;"#
         }
     } else {
         indoc! {r#"
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | null;"#
         }
     };
 
@@ -349,7 +484,10 @@ fn test_untagged_enum_with_namespace() {
                 /**
                  * Comment for Struct
                  */
-                export type Struct = { x: string; y: number };
+                export type Struct = {
+                    x: string;
+                    y: number;
+                };
                 /**
                  * Comment for EmptyStruct
                  */
@@ -375,7 +513,10 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | undefined;"#
         }
     } else {
         indoc! {r#"
@@ -387,7 +528,10 @@ fn test_untagged_enum_with_namespace() {
                 /**
                  * Comment for Struct
                  */
-                export type Struct = { x: string; y: number };
+                export type Struct = {
+                    x: string;
+                    y: number;
+                };
                 /**
                  * Comment for EmptyStruct
                  */
@@ -413,7 +557,10 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | null;"#
         }
     };
 
@@ -430,7 +577,17 @@ fn test_renamed_enum() {
     }
 
     let expected = indoc! {r#"
-        export type Renamed = { First: { fooBar: string; bazQuoox: number } } | { Second: { asdfAsdf: string; qwerQwer: number } };"#
+        export type Renamed = {
+            First: {
+                fooBar: string;
+                bazQuoox: number;
+            };
+        } | {
+            Second: {
+                asdfAsdf: string;
+                qwerQwer: number;
+            };
+        };"#
     };
 
     assert_eq!(Renamed::DECL, expected);
@@ -467,27 +624,42 @@ fn test_module_reimport_enum() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { x: string; y: number } };
+            export type Struct = {
+                Struct: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { EmptyStruct: {} };
+            export type EmptyStruct = {
+                EmptyStruct: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = {
+                Tuple: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { EmptyTuple: [] };
+            export type EmptyTuple = {
+                EmptyTuple: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __InternalFoo };
+            export type Newtype = {
+                Newtype: __InternalFoo;
+            };
             /**
              * Comment for Newtype2
              */
-            export type Newtype2 = { Newtype2: __InternalFoo };
+            export type Newtype2 = {
+                Newtype2: __InternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -497,7 +669,22 @@ fn test_module_reimport_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | { Newtype2: Foo } | "Unit";"#
+        export type Internal = {
+            Struct: {
+                x: string;
+                y: number;
+            };
+        } | {
+            EmptyStruct: {};
+        } | {
+            Tuple: [number, string];
+        } | {
+            EmptyTuple: [];
+        } | {
+            Newtype: Foo;
+        } | {
+            Newtype2: Foo;
+        } | "Unit";"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -534,15 +721,21 @@ fn test_module_template_enum() {
             /**
              * Comment for Newtype
              */
-            export type Newtype<T> = { Newtype: __InternalTest<T> };
+            export type Newtype<T> = {
+                Newtype: __InternalTest<T>;
+            };
             /**
              * Comment for NewtypeF
              */
-            export type NewtypeF = { NewtypeF: __InternalTest<__InternalFoo> };
+            export type NewtypeF = {
+                NewtypeF: __InternalTest<__InternalFoo>;
+            };
             /**
              * Comment for NewtypeL
              */
-            export type NewtypeL = { NewtypeL: __InternalTest<__InternalFoo> };
+            export type NewtypeL = {
+                NewtypeL: __InternalTest<__InternalFoo>;
+            };
             /**
              * Comment for Unit
              */
@@ -552,7 +745,13 @@ fn test_module_template_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal<T> = { Newtype: Test<T> } | { NewtypeF: Test<Foo> } | { NewtypeL: Test<Foo> } | "Unit";"#
+        export type Internal<T> = {
+            Newtype: Test<T>;
+        } | {
+            NewtypeF: Test<Foo>;
+        } | {
+            NewtypeL: Test<Foo>;
+        } | "Unit";"#
     };
 
     assert_eq!(expected, Internal::<Foo>::DECL);
@@ -590,7 +789,9 @@ fn test_module_template_enum_inner() {
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __InternalTest<__InternalFoo> };
+            export type Newtype = {
+                Newtype: __InternalTest<__InternalFoo>;
+            };
             /**
              * Comment for Unit
              */
@@ -600,7 +801,9 @@ fn test_module_template_enum_inner() {
         /**
          * Comment for Internal
          */
-        export type Internal = { Newtype: Test<Foo> } | "Unit";"#
+        export type Internal = {
+            Newtype: Test<Foo>;
+        } | "Unit";"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -131,7 +131,6 @@ fn test_externally_tagged_enum_with_namespace() {
         /**
          * Comment for External
          */
-
         export type External = External.Struct | External.EmptyStruct | External.Tuple | External.EmptyTuple | External.Newtype | External.Unit;"#
     };
 
@@ -228,7 +227,6 @@ fn test_internally_tagged_enum_with_namespace() {
         /**
          * Comment for Internal
          */
-
         export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Newtype | Internal.Unit;"#
     };
 
@@ -472,7 +470,6 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-
             export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     } else {

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -24,7 +24,7 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> Tsify for GenericEnum<T, U> {
         type JsType = JsType;
-        const DECL: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
+        const DECL: &'static str = "export type GenericEnum<T, U> = \"Unit\" | {\n    NewType: T;\n} | {\n    Seq: [T, U];\n} | {\n    Map: {\n        x: T;\n        y: U;\n    };\n};";
         const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
             missing_as_null: false,
             hashmap_as_object: false,
@@ -32,7 +32,7 @@ const _: () = {
         };
     }
     #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
+    const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | {\n    NewType: T;\n} | {\n    Seq: [T, U];\n} | {\n    Map: {\n        x: T;\n        y: U;\n    };\n};";
     #[automatically_derived]
     impl<T, U> WasmDescribe for GenericEnum<T, U> {
         #[inline]

--- a/tests/flatten.rs
+++ b/tests/flatten.rs
@@ -68,7 +68,9 @@ fn test_flatten_option() {
             /**
              * Comment for B
              */
-            export type B = { c: number } & (A | {});"
+            export type B = {
+                c: number;
+            } & (A | {});"
         }
     );
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -88,7 +88,16 @@ fn test_generic_enum() {
         /**
          * Comment for GenericEnum
          */
-        export type GenericEnum<T, U> = "Unit" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };"#
+        export type GenericEnum<T, U> = "Unit" | {
+            NewType: T;
+        } | {
+            Seq: [T, U];
+        } | {
+            Map: {
+                x: T;
+                y: U;
+            };
+        };"#
     };
 
     assert_eq!(GenericEnum::<(), ()>::DECL, expected);
@@ -122,21 +131,39 @@ fn test_generic_enum_with_namespace() {
             /**
              * Comment for NewType
              */
-            export type NewType<T> = { NewType: T };
+            export type NewType<T> = {
+                NewType: T;
+            };
             /**
              * Comment for Seq
              */
-            export type Seq<T, U> = { Seq: [T, U] };
+            export type Seq<T, U> = {
+                Seq: [T, U];
+            };
             /**
              * Comment for Map
              */
-            export type Map<T, U> = { Map: { x: T; y: U } };
+            export type Map<T, U> = {
+                Map: {
+                    x: T;
+                    y: U;
+                };
+            };
         }
 
         /**
          * Comment for GenericEnum
          */
-        export type GenericEnum<T, U> = "Unit" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };"#
+        export type GenericEnum<T, U> = "Unit" | {
+            NewType: T;
+        } | {
+            Seq: [T, U];
+        } | {
+            Map: {
+                x: T;
+                y: U;
+            };
+        };"#
     };
 
     assert_eq!(GenericEnum::<(), ()>::DECL, expected);
@@ -210,7 +237,17 @@ fn test_generics_with_default_params() {
     }
 
     let expected = indoc! {r#"
-        export type SerEnum<A, B, C> = "Unit" | { NewType: A } | { Seq: [number, B] } | { Map: { a: number; b: B; c: C } };"#
+        export type SerEnum<A, B, C> = "Unit" | {
+            NewType: A;
+        } | {
+            Seq: [number, B];
+        } | {
+            Map: {
+                a: number;
+                b: B;
+                c: C;
+            };
+        };"#
     };
 
     assert_eq!(SerEnum::<(), (), ()>::DECL, expected);
@@ -225,7 +262,17 @@ fn test_generics_with_default_params() {
     }
 
     let expected = indoc! {r#"
-        export type DeEnum<A, B, C> = "Unit" | { NewType: A } | { Seq: [number, B] } | { Map: { a: number; b: B; c: C } };"#
+        export type DeEnum<A, B, C> = "Unit" | {
+            NewType: A;
+        } | {
+            Seq: [number, B];
+        } | {
+            Map: {
+                a: number;
+                b: B;
+                c: C;
+            };
+        };"#
     };
 
     assert_eq!(DeEnum::<(), (), ()>::DECL, expected);

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -57,7 +57,13 @@ fn test_rename() {
         /**
          * Comment for RenamedEnum
          */
-        export type RenamedEnum = { X: boolean } | { Y: number } | { Z: string };"#
+        export type RenamedEnum = {
+            X: boolean;
+        } | {
+            Y: number;
+        } | {
+            Z: string;
+        };"#
 
     };
 
@@ -113,25 +119,65 @@ fn test_rename_all() {
             /**
              * Comment for snake_case
              */
-            export type snake_case = { snake_case: { foo: boolean; foo_bar: boolean } };
+            export type snake_case = {
+                snake_case: {
+                    foo: boolean;
+                    foo_bar: boolean;
+                };
+            };
             /**
              * Comment for camel_case
              */
-            export type camel_case = { camel_case: { foo: boolean; fooBar: boolean } };
+            export type camel_case = {
+                camel_case: {
+                    foo: boolean;
+                    fooBar: boolean;
+                };
+            };
             /**
              * Comment for kebab_case
              */
-            export type kebab_case = { kebab_case: { foo: boolean; "foo-bar": boolean } };
+            export type kebab_case = {
+                kebab_case: {
+                    foo: boolean;
+                    "foo-bar": boolean;
+                };
+            };
             /**
              * Comment for screaming_snake_case
              */
-            export type screaming_snake_case = { screaming_snake_case: { FOO: boolean; FOO_BAR: boolean } };
+            export type screaming_snake_case = {
+                screaming_snake_case: {
+                    FOO: boolean;
+                    FOO_BAR: boolean;
+                };
+            };
         }
 
         /**
          * Comment for Enum
          */
-        export type Enum = { snake_case: { foo: boolean; foo_bar: boolean } } | { camel_case: { foo: boolean; fooBar: boolean } } | { kebab_case: { foo: boolean; "foo-bar": boolean } } | { screaming_snake_case: { FOO: boolean; FOO_BAR: boolean } };"#
+        export type Enum = {
+            snake_case: {
+                foo: boolean;
+                foo_bar: boolean;
+            };
+        } | {
+            camel_case: {
+                foo: boolean;
+                fooBar: boolean;
+            };
+        } | {
+            kebab_case: {
+                foo: boolean;
+                "foo-bar": boolean;
+            };
+        } | {
+            screaming_snake_case: {
+                FOO: boolean;
+                FOO_BAR: boolean;
+            };
+        };"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -225,8 +271,17 @@ fn test_quote_non_identifiers() {
     }
 
     let expected = indoc! {r#"
-        export type NonIdentifierRenameEnum = { "hello-world": boolean } | { "hel#&*world": number } | { "hello world": string } | { "": number } | { should_not_quote: string };"#
-
+        export type NonIdentifierRenameEnum = {
+            "hello-world": boolean;
+        } | {
+            "hel#&*world": number;
+        } | {
+            "hello world": string;
+        } | {
+            "": number;
+        } | {
+            should_not_quote: string;
+        };"#
     };
 
     assert_eq!(NonIdentifierRenameEnum::DECL, expected);

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -91,11 +91,18 @@ fn test_skip() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { field_b: number; field_c: string } };
+            export type Struct = {
+                Struct: {
+                    field_b: number;
+                    field_c: string;
+                };
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = {
+                Tuple: [number, string];
+            };
             /**
              * Comment for NewType
              */
@@ -105,7 +112,14 @@ fn test_skip() {
         /**
          * Comment for Enum
          */
-        export type Enum = "D" | { Struct: { field_b: number; field_c: string } } | { Tuple: [number, string] } | "NewType";"#
+        export type Enum = "D" | {
+            Struct: {
+                field_b: number;
+                field_c: string;
+            };
+        } | {
+            Tuple: [number, string];
+        } | "NewType";"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -135,21 +149,35 @@ fn test_skip() {
             /**
              * Comment for Unit
              */
-            export type Unit = { type: "Unit" };
+            export type Unit = {
+                type: "Unit";
+            };
             /**
              * Comment for Struct
              */
-            export type Struct = { type: "Struct"; field_b: number };
+            export type Struct = {
+                type: "Struct";
+                field_b: number;
+            };
             /**
              * Comment for NewType
              */
-            export type NewType = { type: "NewType" };
+            export type NewType = {
+                type: "NewType";
+            };
         }
 
         /**
          * Comment for InternalTagEnum
          */
-        export type InternalTagEnum = { type: "Unit" } | { type: "Struct"; field_b: number } | { type: "NewType" };"#
+        export type InternalTagEnum = {
+            type: "Unit";
+        } | {
+            type: "Struct";
+            field_b: number;
+        } | {
+            type: "NewType";
+        };"#
     };
 
     assert_eq!(InternalTagEnum::DECL, expected);

--- a/tests/type_alias.rs
+++ b/tests/type_alias.rs
@@ -62,7 +62,7 @@ fn test_named_fields() {
                  * Comment for b
                  */
                 b: Map<string, bigint>;
-            }"
+            };"
         }
     } else {
         indoc! {"
@@ -78,7 +78,7 @@ fn test_named_fields() {
                  * Comment for b
                  */
                 b: Record<string, number>;
-            }"
+            };"
         }
     };
 
@@ -163,7 +163,7 @@ fn test_nested_struct() {
                  * Comment for a
                  */
                 a: A;
-            }"
+            };"
         }
     );
 }
@@ -197,7 +197,7 @@ fn test_struct_with_borrowed_fields() {
                  * Comment for cow
                  */
                 cow: string;
-            }"
+            };"
         }
     );
 }
@@ -231,7 +231,7 @@ fn test_tagged_struct() {
                  * Comment for y
                  */
                 y: number;
-            }"#
+            };"#
         }
     );
 }

--- a/tests/type_alias.rs
+++ b/tests/type_alias.rs
@@ -1,0 +1,237 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_unit() {
+    /// Comment for Unit
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Unit;
+
+    if cfg!(feature = "js") {
+        assert_eq!(
+            Unit::DECL,
+            indoc! {"
+            /**
+             * Comment for Unit
+             */
+            export type Unit = undefined;"
+            }
+        );
+    } else {
+        assert_eq!(
+            Unit::DECL,
+            indoc! {"
+            /**
+             * Comment for Unit
+             */
+            export type Unit = null;"
+            }
+        );
+    };
+}
+
+#[test]
+fn test_named_fields() {
+    /// Comment for Struct
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct A {
+        /// Comment for a
+        a: (usize, u64),
+        /// Comment for b
+        b: HashMap<String, i128>,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {"
+            /**
+             * Comment for Struct
+             */
+            export type A = {
+                /**
+                 * Comment for a
+                 */
+                a: [number, number];
+                /**
+                 * Comment for b
+                 */
+                b: Map<string, bigint>;
+            }"
+        }
+    } else {
+        indoc! {"
+            /**
+             * Comment for Struct
+             */
+            export type A = {
+                /**
+                 * Comment for a
+                 */
+                a: [number, number];
+                /**
+                 * Comment for b
+                 */
+                b: Record<string, number>;
+            }"
+        }
+    };
+
+    assert_eq!(A::DECL, expected);
+}
+
+#[test]
+fn test_newtype_struct() {
+    /// Comment for Newtype
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Newtype(i32);
+
+    assert_eq!(
+        Newtype::DECL,
+        indoc! {"
+        /**
+         * Comment for Newtype
+         */
+        export type Newtype = number;"
+        }
+    );
+}
+
+#[test]
+fn test_tuple_struct() {
+    /// Comment for Tuple
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Tuple(i32, String);
+    /// Comment for EmptyTuple
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct EmptyTuple();
+
+    assert_eq!(
+        Tuple::DECL,
+        indoc! {"
+        /**
+         * Comment for Tuple
+         */
+        export type Tuple = [number, string];"
+        }
+    );
+    assert_eq!(
+        EmptyTuple::DECL,
+        indoc! {"
+        /**
+         * Comment for EmptyTuple
+         */
+        export type EmptyTuple = [];"
+        }
+    );
+}
+
+#[test]
+fn test_nested_struct() {
+    /// Comment for A
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct A {
+        /// Comment for x
+        x: f64,
+    }
+
+    /// Comment for B
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct B {
+        /// Comment for a
+        a: A,
+    }
+
+    assert_eq!(
+        B::DECL,
+        indoc! {"
+            /**
+             * Comment for B
+             */
+            export type B = {
+                /**
+                 * Comment for a
+                 */
+                a: A;
+            }"
+        }
+    );
+}
+
+#[test]
+fn test_struct_with_borrowed_fields() {
+    use std::borrow::Cow;
+
+    /// Comment for Borrow
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Borrow<'a> {
+        /// Comment for raw
+        raw: &'a str,
+        /// Comment for cow
+        cow: Cow<'a, str>,
+    }
+
+    assert_eq!(
+        Borrow::DECL,
+        indoc! {"
+            /**
+             * Comment for Borrow
+             */
+            export type Borrow = {
+                /**
+                 * Comment for raw
+                 */
+                raw: string;
+                /**
+                 * Comment for cow
+                 */
+                cow: string;
+            }"
+        }
+    );
+}
+
+#[test]
+fn test_tagged_struct() {
+    /// Comment for TaggedStruct
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    #[serde(tag = "type")]
+    struct TaggedStruct {
+        /// Comment for x
+        x: i32,
+        /// Comment for y
+        y: i32,
+    }
+
+    assert_eq!(
+        TaggedStruct::DECL,
+        indoc! {r#"
+            /**
+             * Comment for TaggedStruct
+             */
+            export type TaggedStruct = {
+                type: "TaggedStruct";
+                /**
+                 * Comment for x
+                 */
+                x: number;
+                /**
+                 * Comment for y
+                 */
+                y: number;
+            }"#
+        }
+    );
+}

--- a/tests/type_override.rs
+++ b/tests/type_override.rs
@@ -86,7 +86,16 @@ fn test_enum_with_type_override() {
         /**
          * Comment for Enum
          */
-        export type Enum = { Struct: { x: `tpl_lit_${string}`; y: 0 | 1 | 2 } } | { Tuple: [`tpl_lit_${string}`, 0 | 1 | 2] } | { Newtype: number };"#
+        export type Enum = {
+            Struct: {
+                x: `tpl_lit_${string}`;
+                y: 0 | 1 | 2;
+            };
+        } | {
+            Tuple: [`tpl_lit_${string}`, 0 | 1 | 2];
+        } | {
+            Newtype: number;
+        };"#
     };
 
     assert_eq!(Enum::DECL, expected);

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -6,6 +6,7 @@ use serde_derive_internals::ast::Field;
 pub struct TsifyContainerAttrs {
     pub type_override: Option<String>,
     pub type_params: Option<Vec<String>>,
+    /// Whether to prefer type aliases over interfaces.
     pub type_alias: bool,
     /// Implement `IntoWasmAbi` for the type.
     pub into_wasm_abi: bool,
@@ -24,8 +25,6 @@ pub struct TypeGenerationConfig {
     pub type_prefix: Option<String>,
     /// Universal suffix for generated types
     pub type_suffix: Option<String>,
-    /// Prefer type aliases over interfaces
-    pub type_alias: bool,
     /// Whether missing fields should be represented as null in Typescript
     pub missing_as_null: bool,
     /// Whether a hashmap should be represented as an object in Typescript

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -58,11 +58,11 @@ impl Display for TsInterfaceDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write_doc_comments(f, &self.comments)?;
 
-        write!(f, "export interface {} ", self.id)?;
+        write!(f, "export interface {}", self.id)?;
 
         if !self.type_params.is_empty() {
             let type_params = self.type_params.join(", ");
-            write!(f, "<{type_params}> ")?;
+            write!(f, "<{type_params}>")?;
         }
 
         if !self.extends.is_empty() {
@@ -73,9 +73,10 @@ impl Display for TsInterfaceDecl {
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            write!(f, "extends {extends} ")?;
+            write!(f, " extends {extends}")?;
         }
 
+        write!(f, " ")?;
         TsTypeLit::from(self.body.as_slice()).fmt(f)
     }
 }

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -58,11 +58,11 @@ impl Display for TsInterfaceDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write_doc_comments(f, &self.comments)?;
 
-        write!(f, "export interface {}", self.id)?;
+        write!(f, "export interface {} ", self.id)?;
 
         if !self.type_params.is_empty() {
             let type_params = self.type_params.join(", ");
-            write!(f, "<{type_params}>")?;
+            write!(f, "<{type_params}> ")?;
         }
 
         if !self.extends.is_empty() {
@@ -73,21 +73,10 @@ impl Display for TsInterfaceDecl {
                 .collect::<Vec<_>>()
                 .join(", ");
 
-            write!(f, " extends {extends}")?;
+            write!(f, "extends {extends} ")?;
         }
 
-        if self.body.is_empty() {
-            write!(f, " {{}}")
-        } else {
-            let members = self
-                .body
-                .iter()
-                .map(|elem| format!("\n{};", elem.to_string_with_indent(4)))
-                .collect::<Vec<_>>()
-                .join("");
-
-            write!(f, " {{{members}\n}}")
-        }
+        TsTypeLit::from(self.body.as_slice()).fmt(f)
     }
 }
 

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -98,7 +98,7 @@ impl<'a> Parser<'a> {
 
     fn create_decl(&self, members: Vec<TsTypeElement>, extends: Vec<TsType>) -> Decl {
         // An interface can only extend an identifier/qualified-name with optional type arguments.
-        if extends.iter().all(|ty| ty.is_ref()) {
+        if !self.container.attrs.type_alias && extends.iter().all(|ty| ty.is_ref()) {
             let mut type_ref_names: HashSet<&String> = HashSet::new();
             members.iter().for_each(|member| {
                 type_ref_names.extend(member.type_ann.type_ref_names());

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -67,6 +67,14 @@ impl From<TsTypeElement> for TsTypeLit {
     }
 }
 
+impl From<&[TsTypeElement]> for TsTypeLit {
+    fn from(m: &[TsTypeElement]) -> Self {
+        TsTypeLit {
+            members: m.to_vec(),
+        }
+    }
+}
+
 impl From<TsTypeElement> for TsType {
     fn from(m: TsTypeElement) -> Self {
         TsType::TypeLit(m.into())
@@ -111,17 +119,17 @@ impl From<TsTypeLit> for TsType {
 
 impl Display for TsTypeLit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let members = self
-            .members
-            .iter()
-            .map(|elem| elem.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-
-        if members.is_empty() {
+        if self.members.is_empty() {
             write!(f, "{{}}")
         } else {
-            write!(f, "{{ {members} }}")
+            let members = self
+                .members
+                .iter()
+                .map(|elem| format!("\n{};", elem.to_string_with_indent(4)))
+                .collect::<Vec<_>>()
+                .join("");
+
+            write!(f, "{{{members}\n}}")
         }
     }
 }

--- a/tsify-macros/src/typescript/ts_type.test.rs
+++ b/tsify-macros/src/typescript/ts_type.test.rs
@@ -41,7 +41,7 @@ fn test_basic_types() {
     assert_ts!(config, Vec<i32> | VecDeque<i32> | LinkedList<i32> | &'a [i32], "number[]");
     assert_ts!(config, HashSet<i32> | BTreeSet<i32>, "number[]");
 
-    assert_ts!(config, Result<i32, String>, "{ Ok: number } | { Err: string }");
+    assert_ts!(config, Result<i32, String>, "{\n    Ok: number;\n} | {\n    Err: string;\n}");
     assert_ts!(config, dyn Fn(String, f64) | dyn FnOnce(String, f64) | dyn FnMut(String, f64), "(arg0: string, arg1: number) => void");
     assert_ts!(config, dyn Fn(String) -> i32 | dyn FnOnce(String) -> i32 | dyn FnMut(String) -> i32, "(arg0: string) => number");
 
@@ -57,22 +57,22 @@ fn test_basic_types() {
     assert_ts!(config, [i32; 17], "number[]");
     assert_ts!(config, [i32; 1 + 1], "number[]");
 
-    assert_ts!(config, Duration, "{ secs: number; nanos: number }");
+    assert_ts!(config, Duration, "{\n    secs: number;\n    nanos: number;\n}");
     assert_ts!(
         config,
         SystemTime,
-        "{ secs_since_epoch: number; nanos_since_epoch: number }"
+        "{\n    secs_since_epoch: number;\n    nanos_since_epoch: number;\n}"
     );
 
-    assert_ts!(config, Range<i32>, "{ start: number; end: number }");
+    assert_ts!(config, Range<i32>, "{\n    start: number;\n    end: number;\n}");
     assert_ts!(
         config,
         Range<&'static str>,
-        "{ start: string; end: string }"
+        "{\n    start: string;\n    end: string;\n}"
     );
     assert_ts!(
         config,
         RangeInclusive<usize>,
-        "{ start: number; end: number }"
+        "{\n    start: number;\n    end: number;\n}"
     );
 }

--- a/tsify-macros/src/typescript/ts_type.test.rs
+++ b/tsify-macros/src/typescript/ts_type.test.rs
@@ -57,14 +57,22 @@ fn test_basic_types() {
     assert_ts!(config, [i32; 17], "number[]");
     assert_ts!(config, [i32; 1 + 1], "number[]");
 
-    assert_ts!(config, Duration, "{\n    secs: number;\n    nanos: number;\n}");
+    assert_ts!(
+        config,
+        Duration,
+        "{\n    secs: number;\n    nanos: number;\n}"
+    );
     assert_ts!(
         config,
         SystemTime,
         "{\n    secs_since_epoch: number;\n    nanos_since_epoch: number;\n}"
     );
 
-    assert_ts!(config, Range<i32>, "{\n    start: number;\n    end: number;\n}");
+    assert_ts!(
+        config,
+        Range<i32>,
+        "{\n    start: number;\n    end: number;\n}"
+    );
     assert_ts!(
         config,
         Range<&'static str>,


### PR DESCRIPTION
(see #80)

Adds the `type_alias` argument to `#[tsify]` to conditionally generate type aliases instead of interfaces.

I had to reformat a lot of tests to use indented type aliases, because inline types do not support doc comments at all.
So what was previously:

```typescript
export type NonIdentifierRenameEnum = { "hello-world": boolean; } | { "hel#&*world": number; } | { "hello world": string; } | { "": number; } | { should_not_quote: string; };
```

Will now become this:

```typescript
export type NonIdentifierRenameEnum = {
    "hello-world": boolean;
} | {
    "hel#&*world": number;
} | {
    "hello world": string;
} | {
    "": number;
} | {
    should_not_quote: string;
};
```

Closes #61 