### PR TITLE
Make enum type aliases utilize the namespace types

### DIFF
--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -105,7 +105,7 @@ fn test_externally_tagged_enum_with_namespace() {
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = External.Struct | External.EmptyStruct | External.Tuple | External.EmptyTuple | External.Newtype | External.Unit;"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -181,7 +181,7 @@ fn test_internally_tagged_enum_with_namespace() {
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Newtype | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -273,7 +273,7 @@ fn test_adjacently_tagged_enum_with_namespace() {
         /**
          * Comment for Adjacent
          */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+        export type Adjacent = Adjacent.Struct | Adjacent.EmptyStruct | Adjacent.Tuple | Adjacent.EmptyTuple | Adjacent.Newtype | Adjacent.Unit;"#
     };
 
     assert_eq!(Adjacent::DECL, expected);
@@ -375,7 +375,7 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     } else {
         indoc! {r#"
@@ -413,7 +413,7 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     };
 
@@ -497,7 +497,7 @@ fn test_module_reimport_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | { Newtype2: Foo } | "Unit";"#
+        export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Tuple | Internal.EmptyTuple | Internal.Newtype | Internal.Newtype2 | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -552,7 +552,7 @@ fn test_module_template_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal<T> = { Newtype: Test<T> } | { NewtypeF: Test<Foo> } | { NewtypeL: Test<Foo> } | "Unit";"#
+        export type Internal<T> = Internal.Newtype<T> | Internal.NewtypeF | Internal.NewtypeL | Internal.Unit;"#
     };
 
     assert_eq!(expected, Internal::<Foo>::DECL);
@@ -600,7 +600,7 @@ fn test_module_template_enum_inner() {
         /**
          * Comment for Internal
          */
-        export type Internal = { Newtype: Test<Foo> } | "Unit";"#
+        export type Internal = Internal.Newtype | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -136,7 +136,7 @@ fn test_generic_enum_with_namespace() {
         /**
          * Comment for GenericEnum
          */
-        export type GenericEnum<T, U> = "Unit" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };"#
+        export type GenericEnum<T, U> = GenericEnum.Unit | GenericEnum.NewType<T> | GenericEnum.Seq<T, U> | GenericEnum.Map<T, U>;"#
     };
 
     assert_eq!(GenericEnum::<(), ()>::DECL, expected);

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -131,7 +131,7 @@ fn test_rename_all() {
         /**
          * Comment for Enum
          */
-        export type Enum = { snake_case: { foo: boolean; foo_bar: boolean } } | { camel_case: { foo: boolean; fooBar: boolean } } | { kebab_case: { foo: boolean; "foo-bar": boolean } } | { screaming_snake_case: { FOO: boolean; FOO_BAR: boolean } };"#
+        export type Enum = Enum.snake_case | Enum.camel_case | Enum.kebab_case | Enum.screaming_snake_case;"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -226,7 +226,6 @@ fn test_quote_non_identifiers() {
 
     let expected = indoc! {r#"
         export type NonIdentifierRenameEnum = { "hello-world": boolean } | { "hel#&*world": number } | { "hello world": string } | { "": number } | { should_not_quote: string };"#
-
     };
 
     assert_eq!(NonIdentifierRenameEnum::DECL, expected);

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -105,7 +105,7 @@ fn test_skip() {
         /**
          * Comment for Enum
          */
-        export type Enum = "D" | { Struct: { field_b: number; field_c: string } } | { Tuple: [number, string] } | "NewType";"#
+        export type Enum = Enum.D | Enum.Struct | Enum.Tuple | Enum.NewType;"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -149,7 +149,7 @@ fn test_skip() {
         /**
          * Comment for InternalTagEnum
          */
-        export type InternalTagEnum = { type: "Unit" } | { type: "Struct"; field_b: number } | { type: "NewType" };"#
+        export type InternalTagEnum = InternalTagEnum.Unit | InternalTagEnum.Struct | InternalTagEnum.NewType;"#
     };
 
     assert_eq!(InternalTagEnum::DECL, expected);

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -1,7 +1,6 @@
 use std::ops::Deref;
 use std::{fmt::Display, vec};
 
-use crate::comments::clean_comments;
 use crate::typescript::TsType::Ref;
 use crate::{
     comments::write_doc_comments,
@@ -267,15 +266,15 @@ impl Display for TsEnumDecl {
             type_ann: TsType::Union(
                 self.members
                     .iter()
-                    .map(|member| if self.namespace {
-                        Ref {
-                            name: format!("{}.{}", self.id, member.id),
-                            type_params: vec![],
+                    .map(|member| {
+                        if self.namespace {
+                            Ref {
+                                name: format!("{}.{}", self.id, member.id),
+                                type_params: vec![],
+                            }
+                        } else {
+                            member.type_ann.clone()
                         }
-                    } else {
-                        let mut clone = member.type_ann.clone();
-                        clean_comments(&mut clone);
-                        clone
                     })
                     .collect(),
             ),

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -1,12 +1,11 @@
 use std::ops::Deref;
 use std::{fmt::Display, vec};
 
-use crate::typescript::TsType::Ref;
+use crate::comments::clean_comments;
 use crate::{
     comments::write_doc_comments,
     typescript::{TsType, TsTypeElement, TsTypeLit},
 };
-use crate::comments::clean_comments;
 
 #[derive(Debug, Clone)]
 pub struct TsTypeAliasDecl {
@@ -280,7 +279,10 @@ impl Display for TsEnumDecl {
                                 format!("{}.{}<{}>", self.id, clone.id, type_params)
                             };
 
-                            Ref { name, type_params: vec![] }
+                            TsType::Ref {
+                                name,
+                                type_params: vec![],
+                            }
                         } else {
                             clone.type_ann.clone()
                         }

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 use std::{fmt::Display, vec};
 
 use crate::comments::clean_comments;
+use crate::typescript::TsType::Ref;
 use crate::{
     comments::write_doc_comments,
     typescript::{TsType, TsTypeElement, TsTypeLit},
@@ -266,7 +267,12 @@ impl Display for TsEnumDecl {
             type_ann: TsType::Union(
                 self.members
                     .iter()
-                    .map(|member| {
+                    .map(|member| if self.namespace {
+                        Ref {
+                            name: format!("{}.{}", self.id, member.id),
+                            type_params: vec![],
+                        }
+                    } else {
                         let mut clone = member.type_ann.clone();
                         clean_comments(&mut clone);
                         clone


### PR DESCRIPTION
(see #80)

When using namespaces, this will generate the type alias as a union of the namespace types.

Given:
```typescript
declare namespace GenericEnum {
    export type Unit = "Unit";
    export type NewType<T> = { NewType: T };
    export type Seq<T, U> = { Seq: [T, U] };
    export type Map<T, U> = { Map: { x: T; y: U } };
}
```

Before:

```ts
export type GenericEnum<T, U> = "Unit" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };
```

After:

```ts
export type GenericEnum<T, U> = GenericEnum.Unit | GenericEnum.NewType<T> | GenericEnum.Seq<T, U> | GenericEnum.Map<T, U>;
```

Of course, this only applies if the namespace is actually generated