### PR TITLE
Generating TypeScript enums

### DIFF
--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -10,10 +10,10 @@ struct Foo {
 }
 
 #[test]
-fn test_externally_tagged_enum() {
+fn test_externally_tagged_enum_with_discriminants() {
     /// Comment for External
     #[derive(Tsify)]
-    #[tsify(discriminants = "Xoxo")]
+    #[tsify(discriminants = "Disc")]
     enum External {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -30,7 +30,7 @@ fn test_externally_tagged_enum() {
     }
 
     let expected = indoc! {r#"
-        enum External {
+        export enum Disc {
             /**
              * Comment for Struct
              */
@@ -60,14 +60,14 @@ fn test_externally_tagged_enum() {
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = { [Disc.Struct]: { x: string; y: number } } | { [Disc.EmptyStruct]: {} } | { [Disc.Tuple]: [number, string] } | { [Disc.EmptyTuple]: [] } | { [Disc.Newtype]: Foo } | Disc.Unit;"#
     };
 
     assert_eq!(External::DECL, expected);
 }
 
 #[test]
-fn test_externally_tagged_enum_with_namespace() {
+fn test_externally_tagged_enum_with_namespace_and_discriminants() {
     /// Comment for External
     #[derive(Tsify)]
     #[tsify(namespace, discriminants)]
@@ -87,7 +87,7 @@ fn test_externally_tagged_enum_with_namespace() {
     }
 
     let expected = indoc! {r#"
-        enum External {
+        export enum ExternalType {
             /**
              * Comment for Struct
              */
@@ -122,40 +122,40 @@ fn test_externally_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { x: string; y: number } };
+            export type Struct = { [ExternalType.Struct]: { x: string; y: number } };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { EmptyStruct: {} };
+            export type EmptyStruct = { [ExternalType.EmptyStruct]: {} };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = { [ExternalType.Tuple]: [number, string] };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { EmptyTuple: [] };
+            export type EmptyTuple = { [ExternalType.EmptyTuple]: [] };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __ExternalFoo };
+            export type Newtype = { [ExternalType.Newtype]: __ExternalFoo };
             /**
              * Comment for Unit
              */
-            export type Unit = "Unit";
+            export type Unit = ExternalType.Unit;
         }
 
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = { [ExternalType.Struct]: { x: string; y: number } } | { [ExternalType.EmptyStruct]: {} } | { [ExternalType.Tuple]: [number, string] } | { [ExternalType.EmptyTuple]: [] } | { [ExternalType.Newtype]: Foo } | ExternalType.Unit;"#
     };
 
     assert_eq!(External::DECL, expected);
 }
 
 #[test]
-fn test_internally_tagged_enum() {
+fn test_internally_tagged_enum_with_discriminants() {
     /// Comment for Internal
     #[derive(Tsify)]
     #[tsify(discriminants)]
@@ -172,6 +172,25 @@ fn test_internally_tagged_enum() {
     }
 
     let expected = indoc! {r#"
+        export enum InternalType {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
         /**
          * Comment for Internal
          */
@@ -182,7 +201,7 @@ fn test_internally_tagged_enum() {
 }
 
 #[test]
-fn test_internally_tagged_enum_with_namespace() {
+fn test_internally_tagged_enum_with_namespace_and_discriminants() {
     /// Comment for Internal
     #[derive(Tsify)]
     #[serde(tag = "t")]
@@ -199,6 +218,25 @@ fn test_internally_tagged_enum_with_namespace() {
     }
 
     let expected = indoc! {r#"
+        export enum InternalType {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
         type __InternalFoo = Foo;
         /**
          * Comment for Internal
@@ -207,121 +245,28 @@ fn test_internally_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: "Struct"; x: string; y: number };
+            export type Struct = { t: InternalType.Struct; x: string; y: number };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: "EmptyStruct" };
+            export type EmptyStruct = { t: InternalType.EmptyStruct };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: "Newtype" } & __InternalFoo;
+            export type Newtype = { t: InternalType.Newtype } & __InternalFoo;
             /**
              * Comment for Unit
              */
-            export type Unit = { t: "Unit" };
+            export type Unit = { t: InternalType.Unit };
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = { t: InternalType.Struct; x: string; y: number } | { t: InternalType.EmptyStruct } | ({ t: InternalType.Newtype } & Foo) | { t: InternalType.Unit };"#
     };
 
     assert_eq!(Internal::DECL, expected);
-}
-
-#[test]
-fn test_adjacently_tagged_enum() {
-    /// Comment for Adjacent
-    #[derive(Tsify)]
-    #[tsify(discriminants)]
-    #[serde(tag = "t", content = "c")]
-    enum Adjacent {
-        /// Comment for Struct
-        Struct { x: String, y: i32 },
-        /// Comment for EmptyStruct
-        EmptyStruct {},
-        /// Comment for Tuple
-        Tuple(i32, String),
-        /// Comment for EmptyTuple
-        EmptyTuple(),
-        /// Comment for Newtype
-        Newtype(Foo),
-        /// Comment for Unit
-        Unit,
-    }
-
-    let expected = indoc! {r#"
-        /**
-         * Comment for Adjacent
-         */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
-    };
-
-    assert_eq!(Adjacent::DECL, expected);
-}
-
-#[test]
-fn test_adjacently_tagged_enum_with_namespace() {
-    /// Comment for Adjacent
-    #[derive(Tsify)]
-    #[serde(tag = "t", content = "c")]
-    #[tsify(namespace, discriminants)]
-    enum Adjacent {
-        /// Comment for Struct
-        Struct { x: String, y: i32 },
-        /// Comment for EmptyStruct
-        EmptyStruct {},
-        /// Comment for Tuple
-        Tuple(i32, String),
-        /// Comment for EmptyTuple
-        EmptyTuple(),
-        /// Comment for Newtype
-        Newtype(Foo),
-        /// Comment for Unit
-        Unit,
-    }
-
-    let expected = indoc! {r#"
-        type __AdjacentFoo = Foo;
-        /**
-         * Comment for Adjacent
-         */
-        declare namespace Adjacent {
-            /**
-             * Comment for Struct
-             */
-            export type Struct = { t: "Struct"; c: { x: string; y: number } };
-            /**
-             * Comment for EmptyStruct
-             */
-            export type EmptyStruct = { t: "EmptyStruct"; c: {} };
-            /**
-             * Comment for Tuple
-             */
-            export type Tuple = { t: "Tuple"; c: [number, string] };
-            /**
-             * Comment for EmptyTuple
-             */
-            export type EmptyTuple = { t: "EmptyTuple"; c: [] };
-            /**
-             * Comment for Newtype
-             */
-            export type Newtype = { t: "Newtype"; c: __AdjacentFoo };
-            /**
-             * Comment for Unit
-             */
-            export type Unit = { t: "Unit" };
-        }
-
-        /**
-         * Comment for Adjacent
-         */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
-    };
-
-    assert_eq!(Adjacent::DECL, expected);
 }
 
 #[test]
@@ -347,6 +292,33 @@ fn test_untagged_enum() {
 
     let expected = if cfg!(feature = "js") {
         indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
             /**
              * Comment for Untagged
              */
@@ -354,6 +326,33 @@ fn test_untagged_enum() {
         }
     } else {
         indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
             /**
              * Comment for Untagged
              */
@@ -387,6 +386,33 @@ fn test_untagged_enum_with_namespace() {
 
     let expected = if cfg!(feature = "js") {
         indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
             type __UntaggedFoo = Foo;
             /**
              * Comment for Untagged
@@ -425,6 +451,33 @@ fn test_untagged_enum_with_namespace() {
         }
     } else {
         indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
             type __UntaggedFoo = Foo;
             /**
              * Comment for Untagged
@@ -467,7 +520,7 @@ fn test_untagged_enum_with_namespace() {
 }
 
 #[test]
-fn test_renamed_enum() {
+fn test_enum_rename_all_fields_with_discriminants() {
     #[derive(Tsify)]
     #[serde(rename_all_fields = "camelCase")]
     #[tsify(discriminants)]
@@ -477,16 +530,22 @@ fn test_renamed_enum() {
     }
 
     let expected = indoc! {r#"
-        export type Renamed = { First: { fooBar: string; bazQuoox: number } } | { Second: { asdfAsdf: string; qwerQwer: number } };"#
+        export enum RenamedType {
+            First = "First",
+            Second = "Second",
+        }
+
+        export type Renamed = { [RenamedType.First]: { fooBar: string; bazQuoox: number } } | { [RenamedType.Second]: { asdfAsdf: string; qwerQwer: number } };"#
     };
 
     assert_eq!(Renamed::DECL, expected);
 }
 
 #[test]
-fn test_module_reimport_enum() {
+fn test_enum_rename_all_with_discriminants() {
     /// Comment for Internal
     #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
     #[tsify(namespace, discriminants)]
     enum Internal {
         /// Comment for Struct
@@ -499,13 +558,38 @@ fn test_module_reimport_enum() {
         EmptyTuple(),
         /// Comment for Newtype
         Newtype(Foo),
-        /// Comment for Newtype2
-        Newtype2(Foo),
         /// Comment for Unit
         Unit,
     }
 
     let expected = indoc! {r#"
+        export enum InternalType {
+            /**
+             * Comment for Struct
+             */
+            struct = "struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            emptyStruct = "emptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            tuple = "tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            emptyTuple = "emptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            newtype = "newtype",
+            /**
+             * Comment for Unit
+             */
+            unit = "unit",
+        }
+
         type __InternalFoo = Foo;
         /**
          * Comment for Internal
@@ -514,140 +598,122 @@ fn test_module_reimport_enum() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { x: string; y: number } };
+            export type struct = { [InternalType.struct]: { x: string; y: number } };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { EmptyStruct: {} };
+            export type emptyStruct = { [InternalType.emptyStruct]: {} };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type tuple = { [InternalType.tuple]: [number, string] };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { EmptyTuple: [] };
+            export type emptyTuple = { [InternalType.emptyTuple]: [] };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __InternalFoo };
-            /**
-             * Comment for Newtype2
-             */
-            export type Newtype2 = { Newtype2: __InternalFoo };
+            export type newtype = { [InternalType.newtype]: __InternalFoo };
             /**
              * Comment for Unit
              */
-            export type Unit = "Unit";
+            export type unit = InternalType.unit;
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | { Newtype2: Foo } | "Unit";"#
+        export type Internal = { [InternalType.struct]: { x: string; y: number } } | { [InternalType.emptyStruct]: {} } | { [InternalType.tuple]: [number, string] } | { [InternalType.emptyTuple]: [] } | { [InternalType.newtype]: Foo } | InternalType.unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
 }
 
 #[test]
-fn test_module_template_enum() {
-    /// Comment for Test
-    struct Test<T> {
-        /// Comment for inner
-        inner: T,
-    }
-
+fn test_enum_rename_all_rename_variants_with_discriminants() {
     /// Comment for Internal
     #[derive(Tsify)]
-    #[tsify(namespace, discriminants)]
-    enum Internal<T> {
-        /// Comment for Newtype
-        Newtype(Test<T>),
-        /// Comment for NewtypeF
-        NewtypeF(Test<Foo>),
-        /// Comment for NewtypeL
-        NewtypeL(Test<Foo>),
-        /// Comment for Unit
-        Unit,
-    }
-    let expected = indoc! {r#"
-        type __InternalFoo = Foo;
-        type __InternalTest<A> = Test<A>;
-        /**
-         * Comment for Internal
-         */
-        declare namespace Internal {
-            /**
-             * Comment for Newtype
-             */
-            export type Newtype<T> = { Newtype: __InternalTest<T> };
-            /**
-             * Comment for NewtypeF
-             */
-            export type NewtypeF = { NewtypeF: __InternalTest<__InternalFoo> };
-            /**
-             * Comment for NewtypeL
-             */
-            export type NewtypeL = { NewtypeL: __InternalTest<__InternalFoo> };
-            /**
-             * Comment for Unit
-             */
-            export type Unit = "Unit";
-        }
-
-        /**
-         * Comment for Internal
-         */
-        export type Internal<T> = { Newtype: Test<T> } | { NewtypeF: Test<Foo> } | { NewtypeL: Test<Foo> } | "Unit";"#
-    };
-
-    assert_eq!(expected, Internal::<Foo>::DECL);
-}
-
-struct Test<T> {
-    inner: T,
-}
-
-#[test]
-fn test_module_template_enum_inner() {
-    /// Comment for Test
-    struct Test<T> {
-        /// Comment for inner
-        inner: T,
-    }
-
-    /// Comment for Internal
-    #[derive(Tsify)]
-    #[tsify(namespace, discriminants)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(namespace, discriminants, rename_variants)]
     enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
         /// Comment for Newtype
-        Newtype(Test<Foo>),
+        Newtype(Foo),
         /// Comment for Unit
         Unit,
     }
 
     let expected = indoc! {r#"
+        export enum InternalType {
+            /**
+             * Comment for Struct
+             */
+            Struct = "struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "emptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            Tuple = "tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            EmptyTuple = "emptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "unit",
+        }
+
         type __InternalFoo = Foo;
-        type __InternalTest<A> = Test<A>;
         /**
          * Comment for Internal
          */
         declare namespace Internal {
             /**
+             * Comment for Struct
+             */
+            export type Struct = { [InternalType.Struct]: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { [InternalType.EmptyStruct]: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { [InternalType.Tuple]: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { [InternalType.EmptyTuple]: [] };
+            /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __InternalTest<__InternalFoo> };
+            export type Newtype = { [InternalType.Newtype]: __InternalFoo };
             /**
              * Comment for Unit
              */
-            export type Unit = "Unit";
+            export type Unit = InternalType.Unit;
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { Newtype: Test<Foo> } | "Unit";"#
+        export type Internal = { [InternalType.Struct]: { x: string; y: number } } | { [InternalType.EmptyStruct]: {} } | { [InternalType.Tuple]: [number, string] } | { [InternalType.EmptyTuple]: [] } | { [InternalType.Newtype]: Foo } | InternalType.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -13,7 +13,7 @@ struct Foo {
 fn test_externally_tagged_enum() {
     /// Comment for External
     #[derive(Tsify)]
-    #[tsify(variant_identifier)]
+    #[tsify(discriminants)]
     enum External {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -70,7 +70,7 @@ fn test_externally_tagged_enum() {
 fn test_externally_tagged_enum_with_namespace() {
     /// Comment for External
     #[derive(Tsify)]
-    #[tsify(namespace, variant_identifier)]
+    #[tsify(namespace, discriminants)]
     enum External {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -87,6 +87,33 @@ fn test_externally_tagged_enum_with_namespace() {
     }
 
     let expected = indoc! {r#"
+        enum External {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            Tuple = "Tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            EmptyTuple = "EmptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
         type __ExternalFoo = Foo;
         /**
          * Comment for External
@@ -131,7 +158,7 @@ fn test_externally_tagged_enum_with_namespace() {
 fn test_internally_tagged_enum() {
     /// Comment for Internal
     #[derive(Tsify)]
-    #[tsify(variant_identifier)]
+    #[tsify(discriminants)]
     #[serde(tag = "t")]
     enum Internal {
         /// Comment for Struct
@@ -159,7 +186,7 @@ fn test_internally_tagged_enum_with_namespace() {
     /// Comment for Internal
     #[derive(Tsify)]
     #[serde(tag = "t")]
-    #[tsify(namespace, variant_identifier)]
+    #[tsify(namespace, discriminants)]
     enum Internal {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -208,6 +235,7 @@ fn test_internally_tagged_enum_with_namespace() {
 fn test_adjacently_tagged_enum() {
     /// Comment for Adjacent
     #[derive(Tsify)]
+    #[tsify(discriminants)]
     #[serde(tag = "t", content = "c")]
     enum Adjacent {
         /// Comment for Struct
@@ -239,7 +267,7 @@ fn test_adjacently_tagged_enum_with_namespace() {
     /// Comment for Adjacent
     #[derive(Tsify)]
     #[serde(tag = "t", content = "c")]
-    #[tsify(namespace)]
+    #[tsify(namespace, discriminants)]
     enum Adjacent {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -300,6 +328,7 @@ fn test_adjacently_tagged_enum_with_namespace() {
 fn test_untagged_enum() {
     /// Comment for Untagged
     #[derive(Tsify)]
+    #[tsify(discriminants)]
     #[serde(untagged)]
     enum Untagged {
         /// Comment for Struct
@@ -340,7 +369,7 @@ fn test_untagged_enum_with_namespace() {
     /// Comment for Untagged
     #[derive(Tsify)]
     #[serde(untagged)]
-    #[tsify(namespace)]
+    #[tsify(namespace, discriminants)]
     enum Untagged {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -441,6 +470,7 @@ fn test_untagged_enum_with_namespace() {
 fn test_renamed_enum() {
     #[derive(Tsify)]
     #[serde(rename_all_fields = "camelCase")]
+    #[tsify(discriminants)]
     enum Renamed {
         First { foo_bar: String, baz_quoox: i32 },
         Second { asdf_asdf: String, qwer_qwer: i32 },
@@ -457,7 +487,7 @@ fn test_renamed_enum() {
 fn test_module_reimport_enum() {
     /// Comment for Internal
     #[derive(Tsify)]
-    #[tsify(namespace)]
+    #[tsify(namespace, discriminants)]
     enum Internal {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -530,7 +560,7 @@ fn test_module_template_enum() {
 
     /// Comment for Internal
     #[derive(Tsify)]
-    #[tsify(namespace)]
+    #[tsify(namespace, discriminants)]
     enum Internal<T> {
         /// Comment for Newtype
         Newtype(Test<T>),
@@ -589,7 +619,7 @@ fn test_module_template_enum_inner() {
 
     /// Comment for Internal
     #[derive(Tsify)]
-    #[tsify(namespace)]
+    #[tsify(namespace, discriminants)]
     enum Internal {
         /// Comment for Newtype
         Newtype(Test<Foo>),

--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -172,7 +172,7 @@ fn test_internally_tagged_enum_with_discriminants() {
     }
 
     let expected = indoc! {r#"
-        export enum InternalType {
+        export enum InternalT {
             /**
              * Comment for Struct
              */
@@ -194,7 +194,7 @@ fn test_internally_tagged_enum_with_discriminants() {
         /**
          * Comment for Internal
          */
-        export type Internal = { t: InternalType.Struct; x: string; y: number } | { t: InternalType.EmptyStruct } | ({ t: InternalType.Newtype } & Foo) | { t: InternalType.Unit };"#
+        export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -218,7 +218,7 @@ fn test_internally_tagged_enum_with_namespace_and_discriminants() {
     }
 
     let expected = indoc! {r#"
-        export enum InternalType {
+        export enum InternalT {
             /**
              * Comment for Struct
              */
@@ -245,25 +245,25 @@ fn test_internally_tagged_enum_with_namespace_and_discriminants() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: InternalType.Struct; x: string; y: number };
+            export type Struct = { t: InternalT.Struct; x: string; y: number };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: InternalType.EmptyStruct };
+            export type EmptyStruct = { t: InternalT.EmptyStruct };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: InternalType.Newtype } & __InternalFoo;
+            export type Newtype = { t: InternalT.Newtype } & __InternalFoo;
             /**
              * Comment for Unit
              */
-            export type Unit = { t: InternalType.Unit };
+            export type Unit = { t: InternalT.Unit };
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { t: InternalType.Struct; x: string; y: number } | { t: InternalType.EmptyStruct } | ({ t: InternalType.Newtype } & Foo) | { t: InternalType.Unit };"#
+        export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -625,6 +625,68 @@ fn test_enum_rename_all_with_discriminants() {
          * Comment for Internal
          */
         export type Internal = { [InternalType.struct]: { x: string; y: number } } | { [InternalType.emptyStruct]: {} } | { [InternalType.tuple]: [number, string] } | { [InternalType.emptyTuple]: [] } | { [InternalType.newtype]: Foo } | InternalType.unit;"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_enum_rename_all_rename_variants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(namespace, rename_variants)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { struct: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { emptyStruct: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { tuple: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { emptyTuple: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { newtype: __InternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "unit";
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { [InternalType.Struct]: { x: string; y: number } } | { [InternalType.EmptyStruct]: {} } | { [InternalType.Tuple]: [number, string] } | { [InternalType.EmptyTuple]: [] } | { [InternalType.Newtype]: Foo } | InternalType.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -13,7 +13,7 @@ struct Foo {
 fn test_externally_tagged_enum() {
     /// Comment for External
     #[derive(Tsify)]
-    #[tsify(discriminants)]
+    #[tsify(discriminants = "Xoxo")]
     enum External {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -175,7 +175,7 @@ fn test_internally_tagged_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = { t: InternalType.Struct; x: string; y: number } | { t: InternalType.EmptyStruct } | ({ t: InternalType.Newtype } & Foo) | { t: InternalType.Unit };"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -631,68 +631,6 @@ fn test_enum_rename_all_with_discriminants() {
 }
 
 #[test]
-fn test_enum_rename_all_rename_variants() {
-    /// Comment for Internal
-    #[derive(Tsify)]
-    #[serde(rename_all = "camelCase")]
-    #[tsify(namespace, rename_variants)]
-    enum Internal {
-        /// Comment for Struct
-        Struct { x: String, y: i32 },
-        /// Comment for EmptyStruct
-        EmptyStruct {},
-        /// Comment for Tuple
-        Tuple(i32, String),
-        /// Comment for EmptyTuple
-        EmptyTuple(),
-        /// Comment for Newtype
-        Newtype(Foo),
-        /// Comment for Unit
-        Unit,
-    }
-
-    let expected = indoc! {r#"
-        type __InternalFoo = Foo;
-        /**
-         * Comment for Internal
-         */
-        declare namespace Internal {
-            /**
-             * Comment for Struct
-             */
-            export type Struct = { struct: { x: string; y: number } };
-            /**
-             * Comment for EmptyStruct
-             */
-            export type EmptyStruct = { emptyStruct: {} };
-            /**
-             * Comment for Tuple
-             */
-            export type Tuple = { tuple: [number, string] };
-            /**
-             * Comment for EmptyTuple
-             */
-            export type EmptyTuple = { emptyTuple: [] };
-            /**
-             * Comment for Newtype
-             */
-            export type Newtype = { newtype: __InternalFoo };
-            /**
-             * Comment for Unit
-             */
-            export type Unit = "unit";
-        }
-
-        /**
-         * Comment for Internal
-         */
-        export type Internal = { [InternalType.Struct]: { x: string; y: number } } | { [InternalType.EmptyStruct]: {} } | { [InternalType.Tuple]: [number, string] } | { [InternalType.EmptyTuple]: [] } | { [InternalType.Newtype]: Foo } | InternalType.Unit;"#
-    };
-
-    assert_eq!(Internal::DECL, expected);
-}
-
-#[test]
 fn test_enum_rename_all_rename_variants_with_discriminants() {
     /// Comment for Internal
     #[derive(Tsify)]

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -605,3 +605,65 @@ fn test_module_template_enum_inner() {
 
     assert_eq!(Internal::DECL, expected);
 }
+
+#[test]
+fn test_rename_all_rename_variants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(namespace, rename_variants)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { struct: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { emptyStruct: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { tuple: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { emptyTuple: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { newtype: __InternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "unit";
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { struct: { x: string; y: number } } | { emptyStruct: {} } | { tuple: [number, string] } | { emptyTuple: [] } | { newtype: Foo } | "unit";"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}

--- a/tests/value_enum.rs
+++ b/tests/value_enum.rs
@@ -1,0 +1,109 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn value_enum() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(value_enum)]
+    enum External {
+        /// Comment for Struct
+        Alpha,
+        /// Comment for EmptyStruct
+        Beta,
+        /// Comment for Tuple
+        Gamma,
+    }
+
+    let expected = indoc! {r#"
+        export enum External {
+            /**
+             * Comment for Struct
+             */
+            Alpha = "Alpha",
+            /**
+             * Comment for EmptyStruct
+             */
+            Beta = "Beta",
+            /**
+             * Comment for Tuple
+             */
+            Gamma = "Gamma",
+        }"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn value_enum_renamed() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(value_enum)]
+    enum External {
+        /// Comment for Struct
+        Alpha,
+        /// Comment for EmptyStruct
+        Beta,
+        /// Comment for Tuple
+        GammaDelta,
+    }
+
+    let expected = indoc! {r#"
+        export enum External {
+            /**
+             * Comment for Struct
+             */
+            alpha = "alpha",
+            /**
+             * Comment for EmptyStruct
+             */
+            beta = "beta",
+            /**
+             * Comment for Tuple
+             */
+            gammaDelta = "gammaDelta",
+        }"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn value_enum_renamed_variants() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(value_enum, rename_variants)]
+    #[serde(rename_all = "kebab-case")]
+    enum External {
+        /// Comment for Struct
+        Alpha,
+        /// Comment for EmptyStruct
+        Beta,
+        /// Comment for Tuple
+        GammaDelta,
+    }
+
+    let expected = indoc! {r#"
+        export enum External {
+            /**
+             * Comment for Struct
+             */
+            Alpha = "alpha",
+            /**
+             * Comment for EmptyStruct
+             */
+            Beta = "beta",
+            /**
+             * Comment for Tuple
+             */
+            GammaDelta = "gamma-delta",
+        }"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}

--- a/tests/value_enum.rs
+++ b/tests/value_enum.rs
@@ -42,7 +42,7 @@ fn value_enum() {
 fn value_enum_renamed() {
     /// Comment for External
     #[derive(Tsify)]
-    #[serde(rename_all = "camelCase")]
+    #[serde(rename_all = "kebab-case")]
     #[tsify(value_enum)]
     enum External {
         /// Comment for Struct
@@ -66,7 +66,7 @@ fn value_enum_renamed() {
             /**
              * Comment for Tuple
              */
-            gammaDelta = "gammaDelta",
+            "gamma-delta" = "gamma-delta",
         }"#
     };
 

--- a/tests/variant_identifier.rs
+++ b/tests/variant_identifier.rs
@@ -1,0 +1,617 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+struct Foo {
+    a: i32,
+    b: String,
+}
+
+#[test]
+fn test_externally_tagged_enum() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(variant_identifier)]
+    enum External {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        enum ExternalType {
+            Struct,
+            EmptyStruct,
+            Tuple,
+            EmptyTuple,
+            Newtype,
+            Unit,
+        }
+        
+        /**
+         * Comment for External
+         */
+        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn test_empty_enum() {
+    #[derive(Tsify)]
+    enum Empty {}
+
+    let expected = indoc! {r#"
+        export type Empty = void;"#
+    };
+
+    assert_eq!(Empty::DECL, expected);
+}
+
+#[test]
+fn test_externally_tagged_enum_with_namespace() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(namespace)]
+    enum External {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __ExternalFoo = Foo;
+        /**
+         * Comment for External
+         */
+        declare namespace External {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { Struct: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { EmptyStruct: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { Tuple: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { EmptyTuple: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { Newtype: __ExternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "Unit";
+        }
+
+        /**
+         * Comment for External
+         */
+        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn test_internally_tagged_enum() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(tag = "t")]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_internally_tagged_enum_with_namespace() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(tag = "t")]
+    #[tsify(namespace)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { t: "Struct"; x: string; y: number };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { t: "EmptyStruct" };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { t: "Newtype" } & __InternalFoo;
+            /**
+             * Comment for Unit
+             */
+            export type Unit = { t: "Unit" };
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_adjacently_tagged_enum() {
+    /// Comment for Adjacent
+    #[derive(Tsify)]
+    #[serde(tag = "t", content = "c")]
+    enum Adjacent {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        /**
+         * Comment for Adjacent
+         */
+        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+    };
+
+    assert_eq!(Adjacent::DECL, expected);
+}
+
+#[test]
+fn test_adjacently_tagged_enum_with_namespace() {
+    /// Comment for Adjacent
+    #[derive(Tsify)]
+    #[serde(tag = "t", content = "c")]
+    #[tsify(namespace)]
+    enum Adjacent {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __AdjacentFoo = Foo;
+        /**
+         * Comment for Adjacent
+         */
+        declare namespace Adjacent {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { t: "Struct"; c: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { t: "EmptyStruct"; c: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { t: "Tuple"; c: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { t: "EmptyTuple"; c: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { t: "Newtype"; c: __AdjacentFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = { t: "Unit" };
+        }
+
+        /**
+         * Comment for Adjacent
+         */
+        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+    };
+
+    assert_eq!(Adjacent::DECL, expected);
+}
+
+#[test]
+fn test_untagged_enum() {
+    /// Comment for Untagged
+    #[derive(Tsify)]
+    #[serde(untagged)]
+    enum Untagged {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {r#"
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+        }
+    } else {
+        indoc! {r#"
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+        }
+    };
+
+    assert_eq!(Untagged::DECL, expected);
+}
+
+#[test]
+fn test_untagged_enum_with_namespace() {
+    /// Comment for Untagged
+    #[derive(Tsify)]
+    #[serde(untagged)]
+    #[tsify(namespace)]
+    enum Untagged {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {r#"
+            type __UntaggedFoo = Foo;
+            /**
+             * Comment for Untagged
+             */
+            declare namespace Untagged {
+                /**
+                 * Comment for Struct
+                 */
+                export type Struct = { x: string; y: number };
+                /**
+                 * Comment for EmptyStruct
+                 */
+                export type EmptyStruct = {};
+                /**
+                 * Comment for Tuple
+                 */
+                export type Tuple = [number, string];
+                /**
+                 * Comment for EmptyTuple
+                 */
+                export type EmptyTuple = [];
+                /**
+                 * Comment for Newtype
+                 */
+                export type Newtype = __UntaggedFoo;
+                /**
+                 * Comment for Unit
+                 */
+                export type Unit = undefined;
+            }
+
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+        }
+    } else {
+        indoc! {r#"
+            type __UntaggedFoo = Foo;
+            /**
+             * Comment for Untagged
+             */
+            declare namespace Untagged {
+                /**
+                 * Comment for Struct
+                 */
+                export type Struct = { x: string; y: number };
+                /**
+                 * Comment for EmptyStruct
+                 */
+                export type EmptyStruct = {};
+                /**
+                 * Comment for Tuple
+                 */
+                export type Tuple = [number, string];
+                /**
+                 * Comment for EmptyTuple
+                 */
+                export type EmptyTuple = [];
+                /**
+                 * Comment for Newtype
+                 */
+                export type Newtype = __UntaggedFoo;
+                /**
+                 * Comment for Unit
+                 */
+                export type Unit = null;
+            }
+
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+        }
+    };
+
+    assert_eq!(Untagged::DECL, expected);
+}
+
+#[test]
+fn test_renamed_enum() {
+    #[derive(Tsify)]
+    #[serde(rename_all_fields = "camelCase")]
+    enum Renamed {
+        First { foo_bar: String, baz_quoox: i32 },
+        Second { asdf_asdf: String, qwer_qwer: i32 },
+    }
+
+    let expected = indoc! {r#"
+        export type Renamed = { First: { fooBar: string; bazQuoox: number } } | { Second: { asdfAsdf: string; qwerQwer: number } };"#
+    };
+
+    assert_eq!(Renamed::DECL, expected);
+}
+
+#[test]
+fn test_module_reimport_enum() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[tsify(namespace)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Newtype2
+        Newtype2(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { Struct: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { EmptyStruct: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { Tuple: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { EmptyTuple: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { Newtype: __InternalFoo };
+            /**
+             * Comment for Newtype2
+             */
+            export type Newtype2 = { Newtype2: __InternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "Unit";
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | { Newtype2: Foo } | "Unit";"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_module_template_enum() {
+    /// Comment for Test
+    struct Test<T> {
+        /// Comment for inner
+        inner: T,
+    }
+
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[tsify(namespace)]
+    enum Internal<T> {
+        /// Comment for Newtype
+        Newtype(Test<T>),
+        /// Comment for NewtypeF
+        NewtypeF(Test<Foo>),
+        /// Comment for NewtypeL
+        NewtypeL(Test<Foo>),
+        /// Comment for Unit
+        Unit,
+    }
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        type __InternalTest<A> = Test<A>;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype<T> = { Newtype: __InternalTest<T> };
+            /**
+             * Comment for NewtypeF
+             */
+            export type NewtypeF = { NewtypeF: __InternalTest<__InternalFoo> };
+            /**
+             * Comment for NewtypeL
+             */
+            export type NewtypeL = { NewtypeL: __InternalTest<__InternalFoo> };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "Unit";
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal<T> = { Newtype: Test<T> } | { NewtypeF: Test<Foo> } | { NewtypeL: Test<Foo> } | "Unit";"#
+    };
+
+    assert_eq!(expected, Internal::<Foo>::DECL);
+}
+
+struct Test<T> {
+    inner: T,
+}
+
+#[test]
+fn test_module_template_enum_inner() {
+    /// Comment for Test
+    struct Test<T> {
+        /// Comment for inner
+        inner: T,
+    }
+
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[tsify(namespace)]
+    enum Internal {
+        /// Comment for Newtype
+        Newtype(Test<Foo>),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        type __InternalTest<A> = Test<A>;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { Newtype: __InternalTest<__InternalFoo> };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "Unit";
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { Newtype: Test<Foo> } | "Unit";"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}

--- a/tests/variant_identifier.rs
+++ b/tests/variant_identifier.rs
@@ -30,15 +30,33 @@ fn test_externally_tagged_enum() {
     }
 
     let expected = indoc! {r#"
-        enum ExternalType {
-            Struct,
-            EmptyStruct,
-            Tuple,
-            EmptyTuple,
-            Newtype,
-            Unit,
+        enum External {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            Tuple = "Tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            EmptyTuple = "EmptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
         }
-        
+
         /**
          * Comment for External
          */
@@ -49,22 +67,10 @@ fn test_externally_tagged_enum() {
 }
 
 #[test]
-fn test_empty_enum() {
-    #[derive(Tsify)]
-    enum Empty {}
-
-    let expected = indoc! {r#"
-        export type Empty = void;"#
-    };
-
-    assert_eq!(Empty::DECL, expected);
-}
-
-#[test]
 fn test_externally_tagged_enum_with_namespace() {
     /// Comment for External
     #[derive(Tsify)]
-    #[tsify(namespace)]
+    #[tsify(namespace, variant_identifier)]
     enum External {
         /// Comment for Struct
         Struct { x: String, y: i32 },
@@ -125,6 +131,7 @@ fn test_externally_tagged_enum_with_namespace() {
 fn test_internally_tagged_enum() {
     /// Comment for Internal
     #[derive(Tsify)]
+    #[tsify(variant_identifier)]
     #[serde(tag = "t")]
     enum Internal {
         /// Comment for Struct
@@ -152,7 +159,7 @@ fn test_internally_tagged_enum_with_namespace() {
     /// Comment for Internal
     #[derive(Tsify)]
     #[serde(tag = "t")]
-    #[tsify(namespace)]
+    #[tsify(namespace, variant_identifier)]
     enum Internal {
         /// Comment for Struct
         Struct { x: String, y: i32 },

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -10,13 +10,13 @@ pub struct TsifyContainerAttrs {
     pub into_wasm_abi: bool,
     /// Implement `FromWasmAbi` for the type.
     pub from_wasm_abi: bool,
-    /// Whether the type should be wrapped in a Typescript namespace.
+    /// Whether the type should be wrapped in a TypeScript namespace.
     pub namespace: bool,
     /// Information about how the type should be serialized.
     pub ty_config: TypeGenerationConfig,
 }
 
-/// Configuration affecting how Typescript types are generated.
+/// Configuration affecting how TypeScript types are generated.
 #[derive(Debug, Default)]
 pub struct TypeGenerationConfig {
     /// Universal prefix for generated types

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -1,8 +1,6 @@
 use crate::decl::TsValueEnumDecl;
 use serde_derive_internals::ast::Field;
 use serde_derive_internals::attr::{Container, TagType};
-use std::borrow::Cow;
-use syn::GenericParam;
 
 /// Attributes that can be applied to a type decorated with `#[derive(Tsify)]`.
 /// E.g., through `#[tsify(into_wasm_abi)]`.
@@ -35,10 +33,10 @@ pub enum DiscriminantEnumGenerationConfig {
 }
 
 impl DiscriminantEnumGenerationConfig {
-    pub fn as_name(&'_ self) -> Option<Cow<'_, str>> {
+    pub fn as_name(&'_ self) -> Option<&str> {
         match self {
             DiscriminantEnumGenerationConfig::NoGeneration => None,
-            DiscriminantEnumGenerationConfig::WithName(name) => Some(Cow::Borrowed(name)),
+            DiscriminantEnumGenerationConfig::WithName(name) => Some(name),
         }
     }
 

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -16,7 +16,7 @@ pub struct TsifyContainerAttrs {
     /// Must be enum. Whether the variant types should be wrapped in a TypeScript namespace.
     pub namespace: bool,
     /// Must be enum. Whether enum with variant identifiers should be generated.
-    pub variant_identifier: Option<Option<String>>,
+    pub discriminants: Option<Option<String>>,
     /// Must be enum with unit variants only. Whether TypeScript should be generated.
     pub value_enum: bool,
     /// Information about how the type should be serialized.
@@ -113,7 +113,7 @@ impl TsifyContainerAttrs {
                     return Ok(());
                 }
 
-                if meta.path.is_ident("variant_identifier") {
+                if meta.path.is_ident("discriminants") {
                     let value = if meta.input.peek(syn::Token![=]) {
                         // There is an '=' → parse the literal
                         let _: syn::Token![=] = meta.input.parse()?;
@@ -124,12 +124,12 @@ impl TsifyContainerAttrs {
                         None
                     };
                     if !matches!(input.data, syn::Data::Enum(_)) {
-                        return Err(meta.error("#[tsify(variant_identifier)] can only be used on enums"));
+                        return Err(meta.error("#[tsify(discriminants)] can only be used on enums"));
                     }
-                    if attrs.variant_identifier.is_some() {
+                    if attrs.discriminants.is_some() {
                         return Err(meta.error("duplicate attribute"));
                     }
-                    attrs.variant_identifier = Some(value);
+                    attrs.discriminants = Some(value);
                     return Ok(());
                 }
 
@@ -201,7 +201,7 @@ impl TsifyContainerAttrs {
                     return Ok(());
                 }
 
-                Err(meta.error("unsupported tsify attribute, expected one of `type`, `type_params`, `into_wasm_abi`, `from_wasm_abi`, `rename_variant`, namespace`, `variant_identifier`, `value_enum`, `type_prefix`, `type_suffix`, `missing_as_null`, `hashmap_as_object`, `large_number_types_as_bigints`"))
+                Err(meta.error("unsupported tsify attribute, expected one of `type`, `type_params`, `into_wasm_abi`, `from_wasm_abi`, `rename_variant`, namespace`, `discriminants`, `value_enum`, `type_prefix`, `type_suffix`, `missing_as_null`, `hashmap_as_object`, `large_number_types_as_bigints`"))
             })?;
         }
 

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -20,7 +20,8 @@ pub struct Container<'a> {
 impl<'a> Container<'a> {
     pub fn new(serde_container: SerdeContainer<'a>) -> Self {
         let input = &serde_container.original;
-        let attrs = TsifyContainerAttrs::from_derive_input(input);
+        let container = &serde_container.attrs;
+        let attrs = TsifyContainerAttrs::from_derive_input(input, container);
         let errors = ErrorTracker::new();
 
         let attrs = match attrs {

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -114,7 +114,7 @@ pub struct TsEnumDecl {
     pub type_params: Vec<String>,
     pub members: Vec<TsTypeAliasDecl>,
     pub namespace: bool,
-    pub discriminants: Option<Vec<TsValueEnumMember>>,
+    pub discriminants: Option<TsValueEnumDecl>,
     pub comments: Vec<String>,
 }
 
@@ -207,15 +207,10 @@ impl TsEnumDecl {
 
 impl Display for TsEnumDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(members) = self.discriminants.clone() {
-            TsValueEnumDecl {
-                id: self.id.clone(),
-                constant: false,
-                members,
-            }
-            .fmt(f)?;
+        if let Some(discriminants) = &self.discriminants {
+            discriminants.fmt(f)?;
             write!(f, "\n\n")?;
-        }
+        };
 
         if self.namespace {
             let mut type_refs = self

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -1,6 +1,5 @@
 use crate::comments::clean_comments;
-use crate::decl::Decl::TsValueEnum;
-use crate::typescript::{ToStringWithIndent, TsValueEnumLit};
+use crate::typescript::ToStringWithIndent;
 use crate::{
     comments::write_doc_comments,
     typescript::{TsType, TsTypeElement, TsTypeLit, TsValueEnumMember},

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -92,7 +92,7 @@ pub struct TsValueEnumDecl {
 impl Display for TsValueEnumDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let constant_keyword = if self.constant { "const " } else { "" };
-        write!(f, "{}enum {} {{", constant_keyword, self.id)?;
+        write!(f, "export {}enum {} {{", constant_keyword, self.id)?;
         if self.members.is_empty() {
             write!(f, "}}")
         } else {

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -107,14 +107,14 @@ impl Display for TsValueEnumDecl {
     }
 }
 
-/// A Typescript type resulting from an enum declaration.
+/// A TypeScript type resulting from an enum declaration.
 #[derive(Debug)]
 pub struct TsEnumDecl {
     pub id: String,
     pub type_params: Vec<String>,
     pub members: Vec<TsTypeAliasDecl>,
     pub namespace: bool,
-    pub variants: Option<Vec<TsValueEnumMember>>,
+    pub discriminants: Option<Vec<TsValueEnumMember>>,
     pub comments: Vec<String>,
 }
 
@@ -207,7 +207,7 @@ impl TsEnumDecl {
 
 impl Display for TsEnumDecl {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(members) = self.variants.clone() {
+        if let Some(members) = self.discriminants.clone() {
             TsValueEnumDecl {
                 id: self.id.clone(),
                 constant: false,

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -311,11 +311,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_enum(&self, variants: &[Variant]) -> Decl {
-        let mut discriminants = self
-            .container
-            .attrs
-            .discriminants
-            .to_enum_decl(self.container.ident_str.as_ref());
+        let mut discriminants = self.container.attrs.discriminants.to_enum_decl();
 
         let members = variants
             .into_iter()

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -279,7 +279,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_enum(&self, variants: &[Variant]) -> Decl {
-        let mut variant_identifiers = if self.container.attrs.variant_identifier.is_some() {
+        let mut discriminants = if self.container.attrs.discriminants.is_some() {
             Some(vec![])
         } else {
             None
@@ -299,7 +299,7 @@ impl<'a> Parser<'a> {
                     };
                     type_alias.comments = extract_doc_comments(&variant.original.attrs);
 
-                    if let Some(variant_identifiers) = &mut variant_identifiers {
+                    if let Some(variant_identifiers) = &mut discriminants {
                         let id = type_alias.id.clone();
 
                         variant_identifiers.push(TsValueEnumMember {
@@ -350,7 +350,7 @@ impl<'a> Parser<'a> {
                 type_params: relevant_type_params,
                 members,
                 namespace: self.container.attrs.namespace,
-                variants: variant_identifiers,
+                discriminants,
                 comments: extract_doc_comments(&self.container.serde_container.original.attrs),
             })
         }

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -285,7 +285,7 @@ impl<'a> Parser<'a> {
 
     fn parse_value_enum(&self, variants: &[Variant]) -> Decl {
         let members = variants
-            .into_iter()
+            .iter()
             .filter(|v| !v.attrs.skip_serializing() && !v.attrs.skip_deserializing())
             .map(|variant| {
                 let variant_serialized = variant.attrs.name().serialize_name();
@@ -314,7 +314,7 @@ impl<'a> Parser<'a> {
         let mut discriminants = self.container.attrs.discriminants.to_enum_decl();
 
         let members = variants
-            .into_iter()
+            .iter()
             .filter(|v| !v.attrs.skip_serializing() && !v.attrs.skip_deserializing())
             .map(|variant| {
                 let variant_serialized = variant.attrs.name().serialize_name();

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -318,21 +318,21 @@ impl<'a> Parser<'a> {
             .filter(|v| !v.attrs.skip_serializing() && !v.attrs.skip_deserializing())
             .map(|variant| {
                 let variant_serialized = variant.attrs.name().serialize_name();
-                let discriminant_value = if self.container.attrs.rename_variants {
+                let variant_name = if self.container.attrs.rename_variants {
                     variant.ident.to_string()
                 } else {
                     variant_serialized.to_owned()
                 };
 
                 let discriminant = if let Some(discriminants) = &discriminants {
-                    TsTypeElementKey::Var(format!("{}.{}", discriminants.id, discriminant_value))
+                    TsTypeElementKey::Var(format!("{}.{}", discriminants.id, variant_name))
                 } else {
-                    TsTypeElementKey::Lit(discriminant_value.to_owned())
+                    TsTypeElementKey::Lit(variant_serialized.to_owned())
                 };
 
                 let decl = self.create_type_alias_decl(self.parse_variant(variant, discriminant));
                 if let Decl::TsTypeAlias(mut type_alias) = decl {
-                    type_alias.id = discriminant_value;
+                    type_alias.id = variant_name;
                     type_alias.comments = extract_doc_comments(&variant.original.attrs);
 
                     if let Some(discriminants) = &mut discriminants {

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -149,7 +149,7 @@ impl<'a> Parser<'a> {
                 let name = self.container.name();
 
                 let tag_field = TsTypeElement {
-                    key: tag.clone(),
+                    key: tag.clone().into(),
                     type_ann: TsType::Lit(name),
                     optional: false,
                     comments: vec![],
@@ -262,7 +262,7 @@ impl<'a> Parser<'a> {
                 let comments = extract_doc_comments(&field.original.attrs);
 
                 TsTypeElement {
-                    key,
+                    key: key.into(),
                     type_ann,
                     optional: optional || !default_is_none,
                     comments,
@@ -370,7 +370,12 @@ impl<'a> Parser<'a> {
             variant.style
         };
         let type_ann: TsType = self.parse_fields(style, &variant.fields).into();
-        type_ann.with_tag_type(&self.container.attrs.ty_config, name, style, tag_type)
+        type_ann.with_tag_type(
+            &self.container.attrs.ty_config,
+            name.into(),
+            style,
+            tag_type,
+        )
     }
 }
 

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -289,15 +289,15 @@ impl<'a> Parser<'a> {
             .filter(|v| !v.attrs.skip_serializing() && !v.attrs.skip_deserializing())
             .map(|variant| {
                 let variant_serialized = variant.attrs.name().serialize_name();
-                let discriminant_value = if self.container.attrs.rename_variants {
+                let member_value = if self.container.attrs.rename_variants {
                     variant.ident.to_string()
                 } else {
                     variant_serialized.to_owned()
                 };
 
                 TsValueEnumMember {
-                    id: variant_serialized.to_string(),
-                    value: TsValueEnumLit::StringLit(discriminant_value),
+                    id: member_value,
+                    value: TsValueEnumLit::StringLit(variant_serialized.to_owned()),
                     comments: extract_doc_comments(&variant.original.attrs),
                 }
             })

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -4,7 +4,7 @@ use crate::{attrs::TypeGenerationConfig, comments::write_doc_comments};
 
 use super::TsType;
 
-/// Built-in Typescript types.
+/// Built-in TypeScript types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TsKeywordTypeKind {
     /// The `number` type.
@@ -26,8 +26,52 @@ pub enum TsKeywordTypeKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TsTypeElementKey {
+    /// Types members like `x: number` or "x_x": string`
+    Lit(String),
+    /// Types members like `[MyConstants.x]: number` or `"[x]": string`
+    Var(String),
+}
+
+impl Into<TsType> for TsTypeElementKey {
+    fn into(self) -> TsType {
+        match self {
+            TsTypeElementKey::Lit(s) => TsType::Lit(s),
+            TsTypeElementKey::Var(v) => TsType::Computed(v),
+        }
+    }
+}
+
+impl Into<TsTypeElementKey> for String {
+    fn into(self) -> TsTypeElementKey {
+        TsTypeElementKey::Lit(self)
+    }
+}
+
+fn is_js_ident(string: &str) -> bool {
+    !string.is_empty()
+        && !string.starts_with(|c: char| c.is_ascii_digit())
+        && !string.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '$')
+}
+
+impl Display for TsTypeElementKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TsTypeElementKey::Lit(key) => {
+                if is_js_ident(key) {
+                    write!(f, "{key}")
+                } else {
+                    write!(f, "\"{key}\"")
+                }
+            }
+            TsTypeElementKey::Var(key) => write!(f, "[{}]", key),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TsTypeElement {
-    pub key: String,
+    pub key: TsTypeElementKey,
     pub type_ann: TsType,
     pub optional: bool,
     pub comments: Vec<String>,
@@ -36,17 +80,11 @@ pub struct TsTypeElement {
 impl Display for TsTypeElement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let key = &self.key;
+        let optional_ann = if self.optional { "?" } else { "" };
         let type_ann = &self.type_ann;
 
-        let optional_ann = if self.optional { "?" } else { "" };
-
         write_doc_comments(f, &self.comments)?;
-
-        if is_js_ident(key) {
-            write!(f, "{key}{optional_ann}: {type_ann}")
-        } else {
-            write!(f, "\"{key}\"{optional_ann}: {type_ann}")
-        }
+        write!(f, "{}{}: {}", key, optional_ann, type_ann)
     }
 }
 
@@ -68,8 +106,8 @@ pub struct TsTypeLit {
 }
 
 impl TsTypeLit {
-    pub fn get_mut(&mut self, key: &String) -> Option<&mut TsTypeElement> {
-        self.members.iter_mut().find(|member| &member.key == key)
+    pub fn get_mut(&mut self, key: &TsTypeElementKey) -> Option<&mut TsTypeElement> {
+        self.members.iter_mut().find(|member| member.key == *key)
     }
 
     pub fn and(self, other: Self) -> Self {
@@ -168,10 +206,4 @@ impl NullType {
             Self::Undefined => TsType::UNDEFINED,
         }
     }
-}
-
-fn is_js_ident(string: &str) -> bool {
-    !string.is_empty()
-        && !string.starts_with(|c: char| c.is_ascii_digit())
-        && !string.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_' && c != '$')
 }

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -153,6 +153,7 @@ impl Display for TsTypeLit {
     }
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TsValueEnumLit {
     None,

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -33,18 +33,18 @@ pub enum TsTypeElementKey {
     Var(String),
 }
 
-impl Into<TsType> for TsTypeElementKey {
-    fn into(self) -> TsType {
-        match self {
+impl From<TsTypeElementKey> for TsType {
+    fn from(value: TsTypeElementKey) -> Self {
+        match value {
             TsTypeElementKey::Lit(s) => TsType::Lit(s),
             TsTypeElementKey::Var(v) => TsType::Computed(v),
         }
     }
 }
 
-impl Into<TsTypeElementKey> for String {
-    fn into(self) -> TsTypeElementKey {
-        TsTypeElementKey::Lit(self)
+impl From<String> for TsTypeElementKey {
+    fn from(value: String) -> Self {
+        TsTypeElementKey::Lit(value)
     }
 }
 

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -181,7 +181,11 @@ pub struct TsValueEnumMember {
 impl Display for TsValueEnumMember {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write_doc_comments(f, &self.comments)?;
-        write!(f, "{}{}", self.id, self.value)
+        if is_js_ident(self.id.as_str()) {
+            write!(f, "{}{}", self.id, self.value)
+        } else {
+            write!(f, "\"{}\"{}", self.id, self.value)
+        }
     }
 }
 

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -33,17 +33,6 @@ pub struct TsTypeElement {
     pub comments: Vec<String>,
 }
 
-impl TsTypeElement {
-    pub fn to_string_with_indent(&self, indent: usize) -> String {
-        let out = self.to_string();
-        let indent_str = " ".repeat(indent);
-        out.split('\n')
-            .map(|line| format!("{}{}", indent_str, line))
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-}
-
 impl Display for TsTypeElement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let key = &self.key;
@@ -123,6 +112,38 @@ impl Display for TsTypeLit {
         } else {
             write!(f, "{{ {members} }}")
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TsValueEnumLit {
+    None,
+    StringLit(String),
+    NumberLit(String),
+}
+
+impl Display for TsValueEnumLit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TsValueEnumLit::None => Ok(()),
+            TsValueEnumLit::StringLit(value) => write!(f, " = \"{}\"", value),
+            TsValueEnumLit::NumberLit(value) => write!(f, " = {}", value),
+        }
+    }
+}
+
+/// A member in a TypeScript enum, e.g. `Foo = 5,`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TsValueEnumMember {
+    pub id: String,
+    pub value: TsValueEnumLit,
+    pub comments: Vec<String>,
+}
+
+impl Display for TsValueEnumMember {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write_doc_comments(f, &self.comments)?;
+        write!(f, "{}{}", self.id, self.value)
     }
 }
 

--- a/tsify-macros/src/typescript/mod.rs
+++ b/tsify-macros/src/typescript/mod.rs
@@ -1,7 +1,9 @@
 mod basic;
+mod to_string_with_indent;
 mod ts_type;
 mod ts_type_display;
 mod ts_type_from_name;
 
 pub use basic::*;
+pub use to_string_with_indent::*;
 pub use ts_type::*;

--- a/tsify-macros/src/typescript/to_string_with_indent.rs
+++ b/tsify-macros/src/typescript/to_string_with_indent.rs
@@ -1,0 +1,14 @@
+pub trait ToStringWithIndent {
+    fn to_string_with_indent(&self, indent: usize) -> String;
+}
+
+impl<T: ToString> ToStringWithIndent for T {
+    fn to_string_with_indent(&self, indent: usize) -> String {
+        let out = self.to_string();
+        let indent_str = " ".repeat(indent);
+        out.split('\n')
+            .map(|line| format!("{}{}", indent_str, line))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}

--- a/tsify-macros/src/typescript/ts_type.rs
+++ b/tsify-macros/src/typescript/ts_type.rs
@@ -325,7 +325,6 @@ impl TsType {
                 tys.iter().for_each(|t| t.visit(f));
             }
             TsType::Keyword(_) | TsType::Lit(_) | TsType::Computed(_) | TsType::Override { .. } => {
-                ()
             }
         }
     }

--- a/tsify-macros/src/typescript/ts_type.rs
+++ b/tsify-macros/src/typescript/ts_type.rs
@@ -4,7 +4,7 @@ use serde_derive_internals::{ast::Style, attr::TagType};
 
 use crate::attrs::TypeGenerationConfig;
 
-use super::{NullType, TsKeywordTypeKind, TsTypeElement, TsTypeLit};
+use super::{NullType, TsKeywordTypeKind, TsTypeElement, TsTypeElementKey, TsTypeLit};
 
 /// A TypeScript type
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,6 +13,8 @@ pub enum TsType {
     Keyword(TsKeywordTypeKind),
     /// A literal type like `"foo"`, `42`, etc.
     Lit(String),
+    /// A computed type like `foo_bar`, etc.
+    Computed(String),
     /// An array type like `number[]`, `(number | string)[]`, etc.
     Array(Box<Self>),
     /// A tuple type like `[number, string]`, `[number, string, boolean]`, etc.
@@ -224,7 +226,7 @@ impl TsType {
     pub fn with_tag_type(
         self,
         config: &TypeGenerationConfig,
-        name: String,
+        key: TsTypeElementKey,
         style: Style,
         tag_type: &TagType,
     ) -> Self {
@@ -233,10 +235,13 @@ impl TsType {
         match tag_type {
             TagType::External => {
                 if matches!(style, Style::Unit) {
-                    TsType::Lit(name)
+                    match key {
+                        TsTypeElementKey::Lit(s) => TsType::Lit(s),
+                        TsTypeElementKey::Var(v) => TsType::Computed(v),
+                    }
                 } else {
                     TsTypeElement {
-                        key: name,
+                        key,
                         type_ann,
                         optional: false,
                         comments: vec![],
@@ -247,8 +252,8 @@ impl TsType {
             TagType::Internal { tag } => {
                 if type_ann == TsType::nullish(config) {
                     let tag_field: TsType = TsTypeElement {
-                        key: tag.clone(),
-                        type_ann: TsType::Lit(name),
+                        key: tag.clone().into(),
+                        type_ann: key.into(),
                         optional: false,
                         comments: vec![],
                     }
@@ -257,8 +262,8 @@ impl TsType {
                     tag_field
                 } else {
                     let tag_field: TsType = TsTypeElement {
-                        key: tag.clone(),
-                        type_ann: TsType::Lit(name),
+                        key: tag.clone().into(),
+                        type_ann: key.into(),
                         optional: false,
                         comments: vec![],
                     }
@@ -269,8 +274,8 @@ impl TsType {
             }
             TagType::Adjacent { tag, content } => {
                 let tag_field = TsTypeElement {
-                    key: tag.clone(),
-                    type_ann: TsType::Lit(name),
+                    key: tag.clone().into(),
+                    type_ann: key.into(),
                     optional: false,
                     comments: vec![],
                 };
@@ -279,7 +284,7 @@ impl TsType {
                     tag_field.into()
                 } else {
                     let content_field = TsTypeElement {
-                        key: content.clone(),
+                        key: content.clone().into(),
                         type_ann,
                         optional: false,
                         comments: vec![],
@@ -319,7 +324,9 @@ impl TsType {
             TsType::Intersection(tys) | TsType::Union(tys) => {
                 tys.iter().for_each(|t| t.visit(f));
             }
-            TsType::Keyword(_) | TsType::Lit(_) | TsType::Override { .. } => (),
+            TsType::Keyword(_) | TsType::Lit(_) | TsType::Computed(_) | TsType::Override { .. } => {
+                ()
+            }
         }
     }
 

--- a/tsify-macros/src/typescript/ts_type.rs
+++ b/tsify-macros/src/typescript/ts_type.rs
@@ -6,7 +6,7 @@ use crate::attrs::TypeGenerationConfig;
 
 use super::{NullType, TsKeywordTypeKind, TsTypeElement, TsTypeLit};
 
-/// A Typescript type
+/// A TypeScript type
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TsType {
     /// A keyword type like `number`, `string`, etc.

--- a/tsify-macros/src/typescript/ts_type_display.rs
+++ b/tsify-macros/src/typescript/ts_type_display.rs
@@ -14,6 +14,10 @@ impl Display for TsType {
                 write!(f, "\"{lit}\"")
             }
 
+            TsType::Computed(comp) => {
+                write!(f, "{comp}")
+            }
+
             TsType::Array(elem) => match elem.as_ref() {
                 TsType::Union(_) | TsType::Intersection(_) | &TsType::Option(_, _) => {
                     write!(f, "({elem})[]")

--- a/tsify-macros/src/typescript/ts_type_from_name.rs
+++ b/tsify-macros/src/typescript/ts_type_from_name.rs
@@ -10,7 +10,7 @@ macro_rules! type_lit {
         TsType::TypeLit(TsTypeLit {
             members: vec![$(
                 TsTypeElement {
-                    key: stringify!($k).to_string(),
+                    key: stringify!($k).to_string().into(),
                     type_ann: $t,
                     optional: false,
                     comments: vec![],


### PR DESCRIPTION
(see #80)

Adds two different kinds of enums:

1. discriminant enums

Can be generated with enums (possibly along namespaces)

```rust
#[derive(Tsify)]
#[tsify(discriminants)]
#[serde(tag = "t")]
enum Internal {
    /// Comment for Struct
    Struct { x: String, y: i32 },
    /// Comment for EmptyStruct
    EmptyStruct {},
    /// Comment for Newtype
    Newtype(Foo),
    /// Comment for Unit
    Unit,
}
```

Generates
```typescript
export enum InternalT {
    /**
     * Comment for Struct
     */
    Struct = "Struct",
    /**
     * Comment for EmptyStruct
     */
    EmptyStruct = "EmptyStruct",
    /**
     * Comment for Newtype
     */
    Newtype = "Newtype",
    /**
     * Comment for Unit
     */
    Unit = "Unit",
}

/**
 * Comment for Internal
 */
export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };
```

2. Value enums

A limited subset of rust enums (only unit variants, externally tagged) can be turned into value enums.

```rust
#[derive(Tsify)]
#[tsify(value_enum, rename_variants)]
#[serde(rename_all = "kebab-case")]
enum External {
    /// Comment for Struct
    Alpha,
    /// Comment for EmptyStruct
    Beta,
    /// Comment for Tuple
    GammaDelta,
}
```

```typescript
export enum External {
    /**
     * Comment for Struct
     */
    Alpha = "alpha",
    /**
     * Comment for EmptyStruct
     */
    Beta = "beta",
    /**
     * Comment for Tuple
     */
    GammaDelta = "gamma-delta",
}"#
```

The `rename_variants` is another new keyword. It makes sure that serde only renames the discriminant, and not the type referring to it. It also works with namespaces:

```rust
#[derive(Tsify)]
#[serde(rename_all = "camelCase")]
#[tsify(namespace, rename_variants)]
enum Internal {
    Struct { x: String, y: i32 },
    EmptyStruct {},
    Tuple(i32, String),
    EmptyTuple(),
    Newtype(Foo),
    Unit,
}
```

```typescript
type __InternalFoo = Foo;
declare namespace Internal {
    export type Struct = { struct: { x: string; y: number } };
    export type EmptyStruct = { emptyStruct: {} };
    export type Tuple = { tuple: [number, string] };
    export type EmptyTuple = { emptyTuple: [] };
    export type Newtype = { newtype: __InternalFoo };
    export type Unit = "unit";
}

export type Internal = { struct: { x: string; y: number } } | { emptyStruct: {} } | { tuple: [number, string] } | { emptyTuple: [] } | { newtype: Foo } | "unit";
```

The idea behind the name `rename_variants`, that it could be extended to pass values defining _how_ the variant should be renamed, which is unimplemented rn, open to adjust the naming.
