### PR TITLE
Enum features

### DIFF
--- a/tests/affixes.rs
+++ b/tests/affixes.rs
@@ -36,7 +36,11 @@ fn test_prefix() {
     assert_eq!(
         PrefixedEnum::DECL,
         indoc! {"
-            export type SpecialPrefixedEnum = { VariantA: SpecialMyType } | { VariantB: number };"
+            export type SpecialPrefixedEnum = {
+                VariantA: SpecialMyType;
+            } | {
+                VariantB: number;
+            };"
         }
     );
 }
@@ -73,7 +77,11 @@ fn test_suffix() {
     assert_eq!(
         SuffixedEnum::DECL,
         indoc! {"
-            export type SuffixedEnumSpecial = { VariantA: MyTypeSpecial } | { VariantB: number };"
+            export type SuffixedEnumSpecial = {
+                VariantA: MyTypeSpecial;
+            } | {
+                VariantB: number;
+            };"
         }
     );
 }
@@ -110,7 +118,11 @@ fn test_prefix_suffix() {
     assert_eq!(
         DoubleAffixedEnum::DECL,
         indoc! {"
-            export type PreDoubleAffixedEnumSuf = { VariantA: PreMyTypeSuf } | { VariantB: number };"
+            export type PreDoubleAffixedEnumSuf = {
+                VariantA: PreMyTypeSuf;
+            } | {
+                VariantB: number;
+            };"
         }
     );
 }

--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -60,7 +60,20 @@ fn test_externally_tagged_enum_with_discriminants() {
         /**
          * Comment for External
          */
-        export type External = { [Disc.Struct]: { x: string; y: number } } | { [Disc.EmptyStruct]: {} } | { [Disc.Tuple]: [number, string] } | { [Disc.EmptyTuple]: [] } | { [Disc.Newtype]: Foo } | Disc.Unit;"#
+        export type External = {
+            [Disc.Struct]: {
+                x: string;
+                y: number;
+            };
+        } | {
+            [Disc.EmptyStruct]: {};
+        } | {
+            [Disc.Tuple]: [number, string];
+        } | {
+            [Disc.EmptyTuple]: [];
+        } | {
+            [Disc.Newtype]: Foo;
+        } | Disc.Unit;"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -122,23 +135,36 @@ fn test_externally_tagged_enum_with_namespace_and_discriminants() {
             /**
              * Comment for Struct
              */
-            export type Struct = { [ExternalType.Struct]: { x: string; y: number } };
+            export type Struct = {
+                [ExternalType.Struct]: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { [ExternalType.EmptyStruct]: {} };
+            export type EmptyStruct = {
+                [ExternalType.EmptyStruct]: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { [ExternalType.Tuple]: [number, string] };
+            export type Tuple = {
+                [ExternalType.Tuple]: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { [ExternalType.EmptyTuple]: [] };
+            export type EmptyTuple = {
+                [ExternalType.EmptyTuple]: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { [ExternalType.Newtype]: __ExternalFoo };
+            export type Newtype = {
+                [ExternalType.Newtype]: __ExternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -148,7 +174,8 @@ fn test_externally_tagged_enum_with_namespace_and_discriminants() {
         /**
          * Comment for External
          */
-        export type External = { [ExternalType.Struct]: { x: string; y: number } } | { [ExternalType.EmptyStruct]: {} } | { [ExternalType.Tuple]: [number, string] } | { [ExternalType.EmptyTuple]: [] } | { [ExternalType.Newtype]: Foo } | ExternalType.Unit;"#
+        export type External = External.Struct | External.EmptyStruct | External.Tuple | External.EmptyTuple | External.Newtype | External.Unit;"#
+
     };
 
     assert_eq!(External::DECL, expected);
@@ -194,7 +221,17 @@ fn test_internally_tagged_enum_with_discriminants() {
         /**
          * Comment for Internal
          */
-        export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };"#
+        export type Internal = {
+            t: InternalT.Struct;
+            x: string;
+            y: number;
+        } | {
+            t: InternalT.EmptyStruct;
+        } | ({
+            t: InternalT.Newtype;
+        } & Foo) | {
+            t: InternalT.Unit;
+        };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -245,25 +282,35 @@ fn test_internally_tagged_enum_with_namespace_and_discriminants() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: InternalT.Struct; x: string; y: number };
+            export type Struct = {
+                t: InternalT.Struct;
+                x: string;
+                y: number;
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: InternalT.EmptyStruct };
+            export type EmptyStruct = {
+                t: InternalT.EmptyStruct;
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: InternalT.Newtype } & __InternalFoo;
+            export type Newtype = {
+                t: InternalT.Newtype;
+            } & __InternalFoo;
             /**
              * Comment for Unit
              */
-            export type Unit = { t: InternalT.Unit };
+            export type Unit = {
+                t: InternalT.Unit;
+            };
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };"#
+        export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Newtype | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -322,7 +369,10 @@ fn test_untagged_enum() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | undefined;"#
         }
     } else {
         indoc! {r#"
@@ -356,7 +406,10 @@ fn test_untagged_enum() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | null;"#
         }
     };
 
@@ -421,7 +474,10 @@ fn test_untagged_enum_with_namespace() {
                 /**
                  * Comment for Struct
                  */
-                export type Struct = { x: string; y: number };
+                export type Struct = {
+                    x: string;
+                    y: number;
+                };
                 /**
                  * Comment for EmptyStruct
                  */
@@ -447,7 +503,7 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     } else {
         indoc! {r#"
@@ -486,7 +542,10 @@ fn test_untagged_enum_with_namespace() {
                 /**
                  * Comment for Struct
                  */
-                export type Struct = { x: string; y: number };
+                export type Struct = {
+                    x: string;
+                    y: number;
+                };
                 /**
                  * Comment for EmptyStruct
                  */
@@ -512,7 +571,7 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     };
 
@@ -535,7 +594,17 @@ fn test_enum_rename_all_fields_with_discriminants() {
             Second = "Second",
         }
 
-        export type Renamed = { [RenamedType.First]: { fooBar: string; bazQuoox: number } } | { [RenamedType.Second]: { asdfAsdf: string; qwerQwer: number } };"#
+        export type Renamed = {
+            [RenamedType.First]: {
+                fooBar: string;
+                bazQuoox: number;
+            };
+        } | {
+            [RenamedType.Second]: {
+                asdfAsdf: string;
+                qwerQwer: number;
+            };
+        };"#
     };
 
     assert_eq!(Renamed::DECL, expected);
@@ -598,23 +667,36 @@ fn test_enum_rename_all_with_discriminants() {
             /**
              * Comment for Struct
              */
-            export type struct = { [InternalType.struct]: { x: string; y: number } };
+            export type struct = {
+                [InternalType.struct]: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type emptyStruct = { [InternalType.emptyStruct]: {} };
+            export type emptyStruct = {
+                [InternalType.emptyStruct]: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type tuple = { [InternalType.tuple]: [number, string] };
+            export type tuple = {
+                [InternalType.tuple]: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type emptyTuple = { [InternalType.emptyTuple]: [] };
+            export type emptyTuple = {
+                [InternalType.emptyTuple]: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type newtype = { [InternalType.newtype]: __InternalFoo };
+            export type newtype = {
+                [InternalType.newtype]: __InternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -624,7 +706,7 @@ fn test_enum_rename_all_with_discriminants() {
         /**
          * Comment for Internal
          */
-        export type Internal = { [InternalType.struct]: { x: string; y: number } } | { [InternalType.emptyStruct]: {} } | { [InternalType.tuple]: [number, string] } | { [InternalType.emptyTuple]: [] } | { [InternalType.newtype]: Foo } | InternalType.unit;"#
+        export type Internal = Internal.struct | Internal.emptyStruct | Internal.tuple | Internal.emptyTuple | Internal.newtype | Internal.unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -687,23 +769,36 @@ fn test_enum_rename_all_rename_variants_with_discriminants() {
             /**
              * Comment for Struct
              */
-            export type Struct = { [InternalType.Struct]: { x: string; y: number } };
+            export type Struct = {
+                [InternalType.Struct]: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { [InternalType.EmptyStruct]: {} };
+            export type EmptyStruct = {
+                [InternalType.EmptyStruct]: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { [InternalType.Tuple]: [number, string] };
+            export type Tuple = {
+                [InternalType.Tuple]: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { [InternalType.EmptyTuple]: [] };
+            export type EmptyTuple = {
+                [InternalType.EmptyTuple]: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { [InternalType.Newtype]: __InternalFoo };
+            export type Newtype = {
+                [InternalType.Newtype]: __InternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -713,7 +808,7 @@ fn test_enum_rename_all_rename_variants_with_discriminants() {
         /**
          * Comment for Internal
          */
-        export type Internal = { [InternalType.Struct]: { x: string; y: number } } | { [InternalType.EmptyStruct]: {} } | { [InternalType.Tuple]: [number, string] } | { [InternalType.EmptyTuple]: [] } | { [InternalType.Newtype]: Foo } | InternalType.Unit;"#
+        export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Tuple | Internal.EmptyTuple | Internal.Newtype | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/discriminants.rs
+++ b/tests/discriminants.rs
@@ -1,0 +1,720 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+struct Foo {
+    a: i32,
+    b: String,
+}
+
+#[test]
+fn test_externally_tagged_enum_with_discriminants() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(discriminants = "Disc")]
+    enum External {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        export enum Disc {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            Tuple = "Tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            EmptyTuple = "EmptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
+        /**
+         * Comment for External
+         */
+        export type External = { [Disc.Struct]: { x: string; y: number } } | { [Disc.EmptyStruct]: {} } | { [Disc.Tuple]: [number, string] } | { [Disc.EmptyTuple]: [] } | { [Disc.Newtype]: Foo } | Disc.Unit;"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn test_externally_tagged_enum_with_namespace_and_discriminants() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(namespace, discriminants)]
+    enum External {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        export enum ExternalType {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            Tuple = "Tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            EmptyTuple = "EmptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
+        type __ExternalFoo = Foo;
+        /**
+         * Comment for External
+         */
+        declare namespace External {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { [ExternalType.Struct]: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { [ExternalType.EmptyStruct]: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { [ExternalType.Tuple]: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { [ExternalType.EmptyTuple]: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { [ExternalType.Newtype]: __ExternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = ExternalType.Unit;
+        }
+
+        /**
+         * Comment for External
+         */
+        export type External = { [ExternalType.Struct]: { x: string; y: number } } | { [ExternalType.EmptyStruct]: {} } | { [ExternalType.Tuple]: [number, string] } | { [ExternalType.EmptyTuple]: [] } | { [ExternalType.Newtype]: Foo } | ExternalType.Unit;"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn test_internally_tagged_enum_with_discriminants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[tsify(discriminants)]
+    #[serde(tag = "t")]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        export enum InternalT {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_internally_tagged_enum_with_namespace_and_discriminants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(tag = "t")]
+    #[tsify(namespace, discriminants)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        export enum InternalT {
+            /**
+             * Comment for Struct
+             */
+            Struct = "Struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "EmptyStruct",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "Newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "Unit",
+        }
+
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { t: InternalT.Struct; x: string; y: number };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { t: InternalT.EmptyStruct };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { t: InternalT.Newtype } & __InternalFoo;
+            /**
+             * Comment for Unit
+             */
+            export type Unit = { t: InternalT.Unit };
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { t: InternalT.Struct; x: string; y: number } | { t: InternalT.EmptyStruct } | ({ t: InternalT.Newtype } & Foo) | { t: InternalT.Unit };"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_untagged_enum() {
+    /// Comment for Untagged
+    #[derive(Tsify)]
+    #[tsify(discriminants)]
+    #[serde(untagged)]
+    enum Untagged {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+        }
+    } else {
+        indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+        }
+    };
+
+    assert_eq!(Untagged::DECL, expected);
+}
+
+#[test]
+fn test_untagged_enum_with_namespace() {
+    /// Comment for Untagged
+    #[derive(Tsify)]
+    #[serde(untagged)]
+    #[tsify(namespace, discriminants)]
+    enum Untagged {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
+            type __UntaggedFoo = Foo;
+            /**
+             * Comment for Untagged
+             */
+            declare namespace Untagged {
+                /**
+                 * Comment for Struct
+                 */
+                export type Struct = { x: string; y: number };
+                /**
+                 * Comment for EmptyStruct
+                 */
+                export type EmptyStruct = {};
+                /**
+                 * Comment for Tuple
+                 */
+                export type Tuple = [number, string];
+                /**
+                 * Comment for EmptyTuple
+                 */
+                export type EmptyTuple = [];
+                /**
+                 * Comment for Newtype
+                 */
+                export type Newtype = __UntaggedFoo;
+                /**
+                 * Comment for Unit
+                 */
+                export type Unit = undefined;
+            }
+
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+        }
+    } else {
+        indoc! {r#"
+            export enum UntaggedType {
+                /**
+                 * Comment for Struct
+                 */
+                Struct = "Struct",
+                /**
+                 * Comment for EmptyStruct
+                 */
+                EmptyStruct = "EmptyStruct",
+                /**
+                 * Comment for Tuple
+                 */
+                Tuple = "Tuple",
+                /**
+                 * Comment for EmptyTuple
+                 */
+                EmptyTuple = "EmptyTuple",
+                /**
+                 * Comment for Newtype
+                 */
+                Newtype = "Newtype",
+                /**
+                 * Comment for Unit
+                 */
+                Unit = "Unit",
+            }
+
+            type __UntaggedFoo = Foo;
+            /**
+             * Comment for Untagged
+             */
+            declare namespace Untagged {
+                /**
+                 * Comment for Struct
+                 */
+                export type Struct = { x: string; y: number };
+                /**
+                 * Comment for EmptyStruct
+                 */
+                export type EmptyStruct = {};
+                /**
+                 * Comment for Tuple
+                 */
+                export type Tuple = [number, string];
+                /**
+                 * Comment for EmptyTuple
+                 */
+                export type EmptyTuple = [];
+                /**
+                 * Comment for Newtype
+                 */
+                export type Newtype = __UntaggedFoo;
+                /**
+                 * Comment for Unit
+                 */
+                export type Unit = null;
+            }
+
+            /**
+             * Comment for Untagged
+             */
+            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+        }
+    };
+
+    assert_eq!(Untagged::DECL, expected);
+}
+
+#[test]
+fn test_enum_rename_all_fields_with_discriminants() {
+    #[derive(Tsify)]
+    #[serde(rename_all_fields = "camelCase")]
+    #[tsify(discriminants)]
+    enum Renamed {
+        First { foo_bar: String, baz_quoox: i32 },
+        Second { asdf_asdf: String, qwer_qwer: i32 },
+    }
+
+    let expected = indoc! {r#"
+        export enum RenamedType {
+            First = "First",
+            Second = "Second",
+        }
+
+        export type Renamed = { [RenamedType.First]: { fooBar: string; bazQuoox: number } } | { [RenamedType.Second]: { asdfAsdf: string; qwerQwer: number } };"#
+    };
+
+    assert_eq!(Renamed::DECL, expected);
+}
+
+#[test]
+fn test_enum_rename_all_with_discriminants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(namespace, discriminants)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        export enum InternalType {
+            /**
+             * Comment for Struct
+             */
+            struct = "struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            emptyStruct = "emptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            tuple = "tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            emptyTuple = "emptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            newtype = "newtype",
+            /**
+             * Comment for Unit
+             */
+            unit = "unit",
+        }
+
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type struct = { [InternalType.struct]: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type emptyStruct = { [InternalType.emptyStruct]: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type tuple = { [InternalType.tuple]: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type emptyTuple = { [InternalType.emptyTuple]: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type newtype = { [InternalType.newtype]: __InternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type unit = InternalType.unit;
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { [InternalType.struct]: { x: string; y: number } } | { [InternalType.emptyStruct]: {} } | { [InternalType.tuple]: [number, string] } | { [InternalType.emptyTuple]: [] } | { [InternalType.newtype]: Foo } | InternalType.unit;"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}
+
+#[test]
+fn test_enum_rename_all_rename_variants_with_discriminants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(namespace, discriminants, rename_variants)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        export enum InternalType {
+            /**
+             * Comment for Struct
+             */
+            Struct = "struct",
+            /**
+             * Comment for EmptyStruct
+             */
+            EmptyStruct = "emptyStruct",
+            /**
+             * Comment for Tuple
+             */
+            Tuple = "tuple",
+            /**
+             * Comment for EmptyTuple
+             */
+            EmptyTuple = "emptyTuple",
+            /**
+             * Comment for Newtype
+             */
+            Newtype = "newtype",
+            /**
+             * Comment for Unit
+             */
+            Unit = "unit",
+        }
+
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { [InternalType.Struct]: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { [InternalType.EmptyStruct]: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { [InternalType.Tuple]: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { [InternalType.EmptyTuple]: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { [InternalType.Newtype]: __InternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = InternalType.Unit;
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { [InternalType.Struct]: { x: string; y: number } } | { [InternalType.EmptyStruct]: {} } | { [InternalType.Tuple]: [number, string] } | { [InternalType.EmptyTuple]: [] } | { [InternalType.Newtype]: Foo } | InternalType.Unit;"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -131,20 +131,7 @@ fn test_externally_tagged_enum_with_namespace() {
         /**
          * Comment for External
          */
-        export type External = {
-            Struct: {
-                x: string;
-                y: number;
-            };
-        } | {
-            EmptyStruct: {};
-        } | {
-            Tuple: [number, string];
-        } | {
-            EmptyTuple: [];
-        } | {
-            Newtype: Foo;
-        } | "Unit";"#
+        export type External = External.Struct | External.EmptyStruct | External.Tuple | External.EmptyTuple | External.Newtype | External.Unit;"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -240,17 +227,7 @@ fn test_internally_tagged_enum_with_namespace() {
         /**
          * Comment for Internal
          */
-        export type Internal = {
-            t: "Struct";
-            x: string;
-            y: number;
-        } | {
-            t: "EmptyStruct";
-        } | ({
-            t: "Newtype";
-        } & Foo) | {
-            t: "Unit";
-        };"#
+        export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Newtype | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -382,27 +359,7 @@ fn test_adjacently_tagged_enum_with_namespace() {
         /**
          * Comment for Adjacent
          */
-        export type Adjacent = {
-            t: "Struct";
-            c: {
-                x: string;
-                y: number;
-            };
-        } | {
-            t: "EmptyStruct";
-            c: {};
-        } | {
-            t: "Tuple";
-            c: [number, string];
-        } | {
-            t: "EmptyTuple";
-            c: [];
-        } | {
-            t: "Newtype";
-            c: Foo;
-        } | {
-            t: "Unit";
-        };"#
+        export type Adjacent = Adjacent.Struct | Adjacent.EmptyStruct | Adjacent.Tuple | Adjacent.EmptyTuple | Adjacent.Newtype | Adjacent.Unit;"#
     };
 
     assert_eq!(Adjacent::DECL, expected);
@@ -513,10 +470,7 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = {
-                x: string;
-                y: number;
-            } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     } else {
         indoc! {r#"
@@ -557,10 +511,7 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = {
-                x: string;
-                y: number;
-            } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = Untagged.Struct | Untagged.EmptyStruct | Untagged.Tuple | Untagged.EmptyTuple | Untagged.Newtype | Untagged.Unit;"#
         }
     };
 
@@ -669,22 +620,7 @@ fn test_module_reimport_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = {
-            Struct: {
-                x: string;
-                y: number;
-            };
-        } | {
-            EmptyStruct: {};
-        } | {
-            Tuple: [number, string];
-        } | {
-            EmptyTuple: [];
-        } | {
-            Newtype: Foo;
-        } | {
-            Newtype2: Foo;
-        } | "Unit";"#
+        export type Internal = Internal.Struct | Internal.EmptyStruct | Internal.Tuple | Internal.EmptyTuple | Internal.Newtype | Internal.Newtype2 | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -745,13 +681,7 @@ fn test_module_template_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal<T> = {
-            Newtype: Test<T>;
-        } | {
-            NewtypeF: Test<Foo>;
-        } | {
-            NewtypeL: Test<Foo>;
-        } | "Unit";"#
+        export type Internal<T> = Internal.Newtype<T> | Internal.NewtypeF | Internal.NewtypeL | Internal.Unit;"#
     };
 
     assert_eq!(expected, Internal::<Foo>::DECL);
@@ -801,71 +731,7 @@ fn test_module_template_enum_inner() {
         /**
          * Comment for Internal
          */
-        export type Internal = {
-            Newtype: Test<Foo>;
-        } | "Unit";"#
-    };
-
-    assert_eq!(Internal::DECL, expected);
-}
-
-#[test]
-fn test_rename_all_rename_variants() {
-    /// Comment for Internal
-    #[derive(Tsify)]
-    #[serde(rename_all = "camelCase")]
-    #[tsify(namespace, rename_variants)]
-    enum Internal {
-        /// Comment for Struct
-        Struct { x: String, y: i32 },
-        /// Comment for EmptyStruct
-        EmptyStruct {},
-        /// Comment for Tuple
-        Tuple(i32, String),
-        /// Comment for EmptyTuple
-        EmptyTuple(),
-        /// Comment for Newtype
-        Newtype(Foo),
-        /// Comment for Unit
-        Unit,
-    }
-
-    let expected = indoc! {r#"
-        type __InternalFoo = Foo;
-        /**
-         * Comment for Internal
-         */
-        declare namespace Internal {
-            /**
-             * Comment for Struct
-             */
-            export type Struct = { struct: { x: string; y: number } };
-            /**
-             * Comment for EmptyStruct
-             */
-            export type EmptyStruct = { emptyStruct: {} };
-            /**
-             * Comment for Tuple
-             */
-            export type Tuple = { tuple: [number, string] };
-            /**
-             * Comment for EmptyTuple
-             */
-            export type EmptyTuple = { emptyTuple: [] };
-            /**
-             * Comment for Newtype
-             */
-            export type Newtype = { newtype: __InternalFoo };
-            /**
-             * Comment for Unit
-             */
-            export type Unit = "unit";
-        }
-
-        /**
-         * Comment for Internal
-         */
-        export type Internal = { struct: { x: string; y: number } } | { emptyStruct: {} } | { tuple: [number, string] } | { emptyTuple: [] } | { newtype: Foo } | "unit";"#
+        export type Internal = Internal.Newtype | Internal.Unit;"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -32,7 +32,20 @@ fn test_externally_tagged_enum() {
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = {
+            Struct: {
+                x: string;
+                y: number;
+            };
+        } | {
+            EmptyStruct: {};
+        } | {
+            Tuple: [number, string];
+        } | {
+            EmptyTuple: [];
+        } | {
+            Newtype: Foo;
+        } | "Unit";"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -79,23 +92,36 @@ fn test_externally_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { x: string; y: number } };
+            export type Struct = {
+                Struct: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { EmptyStruct: {} };
+            export type EmptyStruct = {
+                EmptyStruct: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = {
+                Tuple: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { EmptyTuple: [] };
+            export type EmptyTuple = {
+                EmptyTuple: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __ExternalFoo };
+            export type Newtype = {
+                Newtype: __ExternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -105,7 +131,20 @@ fn test_externally_tagged_enum_with_namespace() {
         /**
          * Comment for External
          */
-        export type External = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | "Unit";"#
+        export type External = {
+            Struct: {
+                x: string;
+                y: number;
+            };
+        } | {
+            EmptyStruct: {};
+        } | {
+            Tuple: [number, string];
+        } | {
+            EmptyTuple: [];
+        } | {
+            Newtype: Foo;
+        } | "Unit";"#
     };
 
     assert_eq!(External::DECL, expected);
@@ -131,7 +170,17 @@ fn test_internally_tagged_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = {
+            t: "Struct";
+            x: string;
+            y: number;
+        } | {
+            t: "EmptyStruct";
+        } | ({
+            t: "Newtype";
+        } & Foo) | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -163,25 +212,45 @@ fn test_internally_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: "Struct"; x: string; y: number };
+            export type Struct = {
+                t: "Struct";
+                x: string;
+                y: number;
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: "EmptyStruct" };
+            export type EmptyStruct = {
+                t: "EmptyStruct";
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: "Newtype" } & __InternalFoo;
+            export type Newtype = {
+                t: "Newtype";
+            } & __InternalFoo;
             /**
              * Comment for Unit
              */
-            export type Unit = { t: "Unit" };
+            export type Unit = {
+                t: "Unit";
+            };
         }
 
         /**
          * Comment for Internal
          */
-        export type Internal = { t: "Struct"; x: string; y: number } | { t: "EmptyStruct" } | ({ t: "Newtype" } & Foo) | { t: "Unit" };"#
+        export type Internal = {
+            t: "Struct";
+            x: string;
+            y: number;
+        } | {
+            t: "EmptyStruct";
+        } | ({
+            t: "Newtype";
+        } & Foo) | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -211,7 +280,27 @@ fn test_adjacently_tagged_enum() {
         /**
          * Comment for Adjacent
          */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+        export type Adjacent = {
+            t: "Struct";
+            c: {
+                x: string;
+                y: number;
+            };
+        } | {
+            t: "EmptyStruct";
+            c: {};
+        } | {
+            t: "Tuple";
+            c: [number, string];
+        } | {
+            t: "EmptyTuple";
+            c: [];
+        } | {
+            t: "Newtype";
+            c: Foo;
+        } | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Adjacent::DECL, expected);
@@ -247,33 +336,73 @@ fn test_adjacently_tagged_enum_with_namespace() {
             /**
              * Comment for Struct
              */
-            export type Struct = { t: "Struct"; c: { x: string; y: number } };
+            export type Struct = {
+                t: "Struct";
+                c: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { t: "EmptyStruct"; c: {} };
+            export type EmptyStruct = {
+                t: "EmptyStruct";
+                c: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { t: "Tuple"; c: [number, string] };
+            export type Tuple = {
+                t: "Tuple";
+                c: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { t: "EmptyTuple"; c: [] };
+            export type EmptyTuple = {
+                t: "EmptyTuple";
+                c: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { t: "Newtype"; c: __AdjacentFoo };
+            export type Newtype = {
+                t: "Newtype";
+                c: __AdjacentFoo;
+            };
             /**
              * Comment for Unit
              */
-            export type Unit = { t: "Unit" };
+            export type Unit = {
+                t: "Unit";
+            };
         }
 
         /**
          * Comment for Adjacent
          */
-        export type Adjacent = { t: "Struct"; c: { x: string; y: number } } | { t: "EmptyStruct"; c: {} } | { t: "Tuple"; c: [number, string] } | { t: "EmptyTuple"; c: [] } | { t: "Newtype"; c: Foo } | { t: "Unit" };"#
+        export type Adjacent = {
+            t: "Struct";
+            c: {
+                x: string;
+                y: number;
+            };
+        } | {
+            t: "EmptyStruct";
+            c: {};
+        } | {
+            t: "Tuple";
+            c: [number, string];
+        } | {
+            t: "EmptyTuple";
+            c: [];
+        } | {
+            t: "Newtype";
+            c: Foo;
+        } | {
+            t: "Unit";
+        };"#
     };
 
     assert_eq!(Adjacent::DECL, expected);
@@ -304,14 +433,20 @@ fn test_untagged_enum() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | undefined;"#
         }
     } else {
         indoc! {r#"
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | null;"#
         }
     };
 
@@ -349,7 +484,10 @@ fn test_untagged_enum_with_namespace() {
                 /**
                  * Comment for Struct
                  */
-                export type Struct = { x: string; y: number };
+                export type Struct = {
+                    x: string;
+                    y: number;
+                };
                 /**
                  * Comment for EmptyStruct
                  */
@@ -375,7 +513,10 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | undefined;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | undefined;"#
         }
     } else {
         indoc! {r#"
@@ -387,7 +528,10 @@ fn test_untagged_enum_with_namespace() {
                 /**
                  * Comment for Struct
                  */
-                export type Struct = { x: string; y: number };
+                export type Struct = {
+                    x: string;
+                    y: number;
+                };
                 /**
                  * Comment for EmptyStruct
                  */
@@ -413,7 +557,10 @@ fn test_untagged_enum_with_namespace() {
             /**
              * Comment for Untagged
              */
-            export type Untagged = { x: string; y: number } | {} | [number, string] | [] | Foo | null;"#
+            export type Untagged = {
+                x: string;
+                y: number;
+            } | {} | [number, string] | [] | Foo | null;"#
         }
     };
 
@@ -430,7 +577,17 @@ fn test_renamed_enum() {
     }
 
     let expected = indoc! {r#"
-        export type Renamed = { First: { fooBar: string; bazQuoox: number } } | { Second: { asdfAsdf: string; qwerQwer: number } };"#
+        export type Renamed = {
+            First: {
+                fooBar: string;
+                bazQuoox: number;
+            };
+        } | {
+            Second: {
+                asdfAsdf: string;
+                qwerQwer: number;
+            };
+        };"#
     };
 
     assert_eq!(Renamed::DECL, expected);
@@ -467,27 +624,42 @@ fn test_module_reimport_enum() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { x: string; y: number } };
+            export type Struct = {
+                Struct: {
+                    x: string;
+                    y: number;
+                };
+            };
             /**
              * Comment for EmptyStruct
              */
-            export type EmptyStruct = { EmptyStruct: {} };
+            export type EmptyStruct = {
+                EmptyStruct: {};
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = {
+                Tuple: [number, string];
+            };
             /**
              * Comment for EmptyTuple
              */
-            export type EmptyTuple = { EmptyTuple: [] };
+            export type EmptyTuple = {
+                EmptyTuple: [];
+            };
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __InternalFoo };
+            export type Newtype = {
+                Newtype: __InternalFoo;
+            };
             /**
              * Comment for Newtype2
              */
-            export type Newtype2 = { Newtype2: __InternalFoo };
+            export type Newtype2 = {
+                Newtype2: __InternalFoo;
+            };
             /**
              * Comment for Unit
              */
@@ -497,7 +669,22 @@ fn test_module_reimport_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal = { Struct: { x: string; y: number } } | { EmptyStruct: {} } | { Tuple: [number, string] } | { EmptyTuple: [] } | { Newtype: Foo } | { Newtype2: Foo } | "Unit";"#
+        export type Internal = {
+            Struct: {
+                x: string;
+                y: number;
+            };
+        } | {
+            EmptyStruct: {};
+        } | {
+            Tuple: [number, string];
+        } | {
+            EmptyTuple: [];
+        } | {
+            Newtype: Foo;
+        } | {
+            Newtype2: Foo;
+        } | "Unit";"#
     };
 
     assert_eq!(Internal::DECL, expected);
@@ -534,15 +721,21 @@ fn test_module_template_enum() {
             /**
              * Comment for Newtype
              */
-            export type Newtype<T> = { Newtype: __InternalTest<T> };
+            export type Newtype<T> = {
+                Newtype: __InternalTest<T>;
+            };
             /**
              * Comment for NewtypeF
              */
-            export type NewtypeF = { NewtypeF: __InternalTest<__InternalFoo> };
+            export type NewtypeF = {
+                NewtypeF: __InternalTest<__InternalFoo>;
+            };
             /**
              * Comment for NewtypeL
              */
-            export type NewtypeL = { NewtypeL: __InternalTest<__InternalFoo> };
+            export type NewtypeL = {
+                NewtypeL: __InternalTest<__InternalFoo>;
+            };
             /**
              * Comment for Unit
              */
@@ -552,7 +745,13 @@ fn test_module_template_enum() {
         /**
          * Comment for Internal
          */
-        export type Internal<T> = { Newtype: Test<T> } | { NewtypeF: Test<Foo> } | { NewtypeL: Test<Foo> } | "Unit";"#
+        export type Internal<T> = {
+            Newtype: Test<T>;
+        } | {
+            NewtypeF: Test<Foo>;
+        } | {
+            NewtypeL: Test<Foo>;
+        } | "Unit";"#
     };
 
     assert_eq!(expected, Internal::<Foo>::DECL);
@@ -590,7 +789,9 @@ fn test_module_template_enum_inner() {
             /**
              * Comment for Newtype
              */
-            export type Newtype = { Newtype: __InternalTest<__InternalFoo> };
+            export type Newtype = {
+                Newtype: __InternalTest<__InternalFoo>;
+            };
             /**
              * Comment for Unit
              */
@@ -600,7 +801,9 @@ fn test_module_template_enum_inner() {
         /**
          * Comment for Internal
          */
-        export type Internal = { Newtype: Test<Foo> } | "Unit";"#
+        export type Internal = {
+            Newtype: Test<Foo>;
+        } | "Unit";"#
     };
 
     assert_eq!(Internal::DECL, expected);

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -605,3 +605,65 @@ fn test_module_template_enum_inner() {
 
     assert_eq!(Internal::DECL, expected);
 }
+
+#[test]
+fn test_rename_all_rename_variants() {
+    /// Comment for Internal
+    #[derive(Tsify)]
+    #[serde(rename_all = "camelCase")]
+    #[tsify(namespace, rename_variants)]
+    enum Internal {
+        /// Comment for Struct
+        Struct { x: String, y: i32 },
+        /// Comment for EmptyStruct
+        EmptyStruct {},
+        /// Comment for Tuple
+        Tuple(i32, String),
+        /// Comment for EmptyTuple
+        EmptyTuple(),
+        /// Comment for Newtype
+        Newtype(Foo),
+        /// Comment for Unit
+        Unit,
+    }
+
+    let expected = indoc! {r#"
+        type __InternalFoo = Foo;
+        /**
+         * Comment for Internal
+         */
+        declare namespace Internal {
+            /**
+             * Comment for Struct
+             */
+            export type Struct = { struct: { x: string; y: number } };
+            /**
+             * Comment for EmptyStruct
+             */
+            export type EmptyStruct = { emptyStruct: {} };
+            /**
+             * Comment for Tuple
+             */
+            export type Tuple = { tuple: [number, string] };
+            /**
+             * Comment for EmptyTuple
+             */
+            export type EmptyTuple = { emptyTuple: [] };
+            /**
+             * Comment for Newtype
+             */
+            export type Newtype = { newtype: __InternalFoo };
+            /**
+             * Comment for Unit
+             */
+            export type Unit = "unit";
+        }
+
+        /**
+         * Comment for Internal
+         */
+        export type Internal = { struct: { x: string; y: number } } | { emptyStruct: {} } | { tuple: [number, string] } | { emptyTuple: [] } | { newtype: Foo } | "unit";"#
+    };
+
+    assert_eq!(Internal::DECL, expected);
+}

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -24,7 +24,7 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> Tsify for GenericEnum<T, U> {
         type JsType = JsType;
-        const DECL: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
+        const DECL: &'static str = "export type GenericEnum<T, U> = \"Unit\" | {\n    NewType: T;\n} | {\n    Seq: [T, U];\n} | {\n    Map: {\n        x: T;\n        y: U;\n    };\n};";
         const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
             missing_as_null: false,
             hashmap_as_object: false,
@@ -32,7 +32,7 @@ const _: () = {
         };
     }
     #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
+    const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | {\n    NewType: T;\n} | {\n    Seq: [T, U];\n} | {\n    Map: {\n        x: T;\n        y: U;\n    };\n};";
     #[automatically_derived]
     impl<T, U> WasmDescribe for GenericEnum<T, U> {
         #[inline]

--- a/tests/flatten.rs
+++ b/tests/flatten.rs
@@ -68,7 +68,9 @@ fn test_flatten_option() {
             /**
              * Comment for B
              */
-            export type B = { c: number } & (A | {});"
+            export type B = {
+                c: number;
+            } & (A | {});"
         }
     );
 }

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -88,7 +88,16 @@ fn test_generic_enum() {
         /**
          * Comment for GenericEnum
          */
-        export type GenericEnum<T, U> = "Unit" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };"#
+        export type GenericEnum<T, U> = "Unit" | {
+            NewType: T;
+        } | {
+            Seq: [T, U];
+        } | {
+            Map: {
+                x: T;
+                y: U;
+            };
+        };"#
     };
 
     assert_eq!(GenericEnum::<(), ()>::DECL, expected);
@@ -122,21 +131,39 @@ fn test_generic_enum_with_namespace() {
             /**
              * Comment for NewType
              */
-            export type NewType<T> = { NewType: T };
+            export type NewType<T> = {
+                NewType: T;
+            };
             /**
              * Comment for Seq
              */
-            export type Seq<T, U> = { Seq: [T, U] };
+            export type Seq<T, U> = {
+                Seq: [T, U];
+            };
             /**
              * Comment for Map
              */
-            export type Map<T, U> = { Map: { x: T; y: U } };
+            export type Map<T, U> = {
+                Map: {
+                    x: T;
+                    y: U;
+                };
+            };
         }
 
         /**
          * Comment for GenericEnum
          */
-        export type GenericEnum<T, U> = "Unit" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };"#
+        export type GenericEnum<T, U> = "Unit" | {
+            NewType: T;
+        } | {
+            Seq: [T, U];
+        } | {
+            Map: {
+                x: T;
+                y: U;
+            };
+        };"#
     };
 
     assert_eq!(GenericEnum::<(), ()>::DECL, expected);
@@ -210,7 +237,17 @@ fn test_generics_with_default_params() {
     }
 
     let expected = indoc! {r#"
-        export type SerEnum<A, B, C> = "Unit" | { NewType: A } | { Seq: [number, B] } | { Map: { a: number; b: B; c: C } };"#
+        export type SerEnum<A, B, C> = "Unit" | {
+            NewType: A;
+        } | {
+            Seq: [number, B];
+        } | {
+            Map: {
+                a: number;
+                b: B;
+                c: C;
+            };
+        };"#
     };
 
     assert_eq!(SerEnum::<(), (), ()>::DECL, expected);
@@ -225,7 +262,17 @@ fn test_generics_with_default_params() {
     }
 
     let expected = indoc! {r#"
-        export type DeEnum<A, B, C> = "Unit" | { NewType: A } | { Seq: [number, B] } | { Map: { a: number; b: B; c: C } };"#
+        export type DeEnum<A, B, C> = "Unit" | {
+            NewType: A;
+        } | {
+            Seq: [number, B];
+        } | {
+            Map: {
+                a: number;
+                b: B;
+                c: C;
+            };
+        };"#
     };
 
     assert_eq!(DeEnum::<(), (), ()>::DECL, expected);

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -154,16 +154,7 @@ fn test_generic_enum_with_namespace() {
         /**
          * Comment for GenericEnum
          */
-        export type GenericEnum<T, U> = "Unit" | {
-            NewType: T;
-        } | {
-            Seq: [T, U];
-        } | {
-            Map: {
-                x: T;
-                y: U;
-            };
-        };"#
+        export type GenericEnum<T, U> = GenericEnum.Unit | GenericEnum.NewType<T> | GenericEnum.Seq<T, U> | GenericEnum.Map<T, U>;"#
     };
 
     assert_eq!(GenericEnum::<(), ()>::DECL, expected);

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -57,7 +57,13 @@ fn test_rename() {
         /**
          * Comment for RenamedEnum
          */
-        export type RenamedEnum = { X: boolean } | { Y: number } | { Z: string };"#
+        export type RenamedEnum = {
+            X: boolean;
+        } | {
+            Y: number;
+        } | {
+            Z: string;
+        };"#
 
     };
 
@@ -113,25 +119,65 @@ fn test_rename_all() {
             /**
              * Comment for snake_case
              */
-            export type snake_case = { snake_case: { foo: boolean; foo_bar: boolean } };
+            export type snake_case = {
+                snake_case: {
+                    foo: boolean;
+                    foo_bar: boolean;
+                };
+            };
             /**
              * Comment for camel_case
              */
-            export type camel_case = { camel_case: { foo: boolean; fooBar: boolean } };
+            export type camel_case = {
+                camel_case: {
+                    foo: boolean;
+                    fooBar: boolean;
+                };
+            };
             /**
              * Comment for kebab_case
              */
-            export type kebab_case = { kebab_case: { foo: boolean; "foo-bar": boolean } };
+            export type kebab_case = {
+                kebab_case: {
+                    foo: boolean;
+                    "foo-bar": boolean;
+                };
+            };
             /**
              * Comment for screaming_snake_case
              */
-            export type screaming_snake_case = { screaming_snake_case: { FOO: boolean; FOO_BAR: boolean } };
+            export type screaming_snake_case = {
+                screaming_snake_case: {
+                    FOO: boolean;
+                    FOO_BAR: boolean;
+                };
+            };
         }
 
         /**
          * Comment for Enum
          */
-        export type Enum = { snake_case: { foo: boolean; foo_bar: boolean } } | { camel_case: { foo: boolean; fooBar: boolean } } | { kebab_case: { foo: boolean; "foo-bar": boolean } } | { screaming_snake_case: { FOO: boolean; FOO_BAR: boolean } };"#
+        export type Enum = {
+            snake_case: {
+                foo: boolean;
+                foo_bar: boolean;
+            };
+        } | {
+            camel_case: {
+                foo: boolean;
+                fooBar: boolean;
+            };
+        } | {
+            kebab_case: {
+                foo: boolean;
+                "foo-bar": boolean;
+            };
+        } | {
+            screaming_snake_case: {
+                FOO: boolean;
+                FOO_BAR: boolean;
+            };
+        };"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -225,8 +271,17 @@ fn test_quote_non_identifiers() {
     }
 
     let expected = indoc! {r#"
-        export type NonIdentifierRenameEnum = { "hello-world": boolean } | { "hel#&*world": number } | { "hello world": string } | { "": number } | { should_not_quote: string };"#
-
+        export type NonIdentifierRenameEnum = {
+            "hello-world": boolean;
+        } | {
+            "hel#&*world": number;
+        } | {
+            "hello world": string;
+        } | {
+            "": number;
+        } | {
+            should_not_quote: string;
+        };"#
     };
 
     assert_eq!(NonIdentifierRenameEnum::DECL, expected);

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -157,27 +157,7 @@ fn test_rename_all() {
         /**
          * Comment for Enum
          */
-        export type Enum = {
-            snake_case: {
-                foo: boolean;
-                foo_bar: boolean;
-            };
-        } | {
-            camel_case: {
-                foo: boolean;
-                fooBar: boolean;
-            };
-        } | {
-            kebab_case: {
-                foo: boolean;
-                "foo-bar": boolean;
-            };
-        } | {
-            screaming_snake_case: {
-                FOO: boolean;
-                FOO_BAR: boolean;
-            };
-        };"#
+        export type Enum = Enum.snake_case | Enum.camel_case | Enum.kebab_case | Enum.screaming_snake_case;"#
     };
 
     assert_eq!(Enum::DECL, expected);

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -112,14 +112,7 @@ fn test_skip() {
         /**
          * Comment for Enum
          */
-        export type Enum = "D" | {
-            Struct: {
-                field_b: number;
-                field_c: string;
-            };
-        } | {
-            Tuple: [number, string];
-        } | "NewType";"#
+        export type Enum = Enum.D | Enum.Struct | Enum.Tuple | Enum.NewType;"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -170,14 +163,7 @@ fn test_skip() {
         /**
          * Comment for InternalTagEnum
          */
-        export type InternalTagEnum = {
-            type: "Unit";
-        } | {
-            type: "Struct";
-            field_b: number;
-        } | {
-            type: "NewType";
-        };"#
+        export type InternalTagEnum = InternalTagEnum.Unit | InternalTagEnum.Struct | InternalTagEnum.NewType;"#
     };
 
     assert_eq!(InternalTagEnum::DECL, expected);

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -91,11 +91,18 @@ fn test_skip() {
             /**
              * Comment for Struct
              */
-            export type Struct = { Struct: { field_b: number; field_c: string } };
+            export type Struct = {
+                Struct: {
+                    field_b: number;
+                    field_c: string;
+                };
+            };
             /**
              * Comment for Tuple
              */
-            export type Tuple = { Tuple: [number, string] };
+            export type Tuple = {
+                Tuple: [number, string];
+            };
             /**
              * Comment for NewType
              */
@@ -105,7 +112,14 @@ fn test_skip() {
         /**
          * Comment for Enum
          */
-        export type Enum = "D" | { Struct: { field_b: number; field_c: string } } | { Tuple: [number, string] } | "NewType";"#
+        export type Enum = "D" | {
+            Struct: {
+                field_b: number;
+                field_c: string;
+            };
+        } | {
+            Tuple: [number, string];
+        } | "NewType";"#
     };
 
     assert_eq!(Enum::DECL, expected);
@@ -135,21 +149,35 @@ fn test_skip() {
             /**
              * Comment for Unit
              */
-            export type Unit = { type: "Unit" };
+            export type Unit = {
+                type: "Unit";
+            };
             /**
              * Comment for Struct
              */
-            export type Struct = { type: "Struct"; field_b: number };
+            export type Struct = {
+                type: "Struct";
+                field_b: number;
+            };
             /**
              * Comment for NewType
              */
-            export type NewType = { type: "NewType" };
+            export type NewType = {
+                type: "NewType";
+            };
         }
 
         /**
          * Comment for InternalTagEnum
          */
-        export type InternalTagEnum = { type: "Unit" } | { type: "Struct"; field_b: number } | { type: "NewType" };"#
+        export type InternalTagEnum = {
+            type: "Unit";
+        } | {
+            type: "Struct";
+            field_b: number;
+        } | {
+            type: "NewType";
+        };"#
     };
 
     assert_eq!(InternalTagEnum::DECL, expected);

--- a/tests/type_alias.rs
+++ b/tests/type_alias.rs
@@ -1,0 +1,237 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn test_unit() {
+    /// Comment for Unit
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Unit;
+
+    if cfg!(feature = "js") {
+        assert_eq!(
+            Unit::DECL,
+            indoc! {"
+            /**
+             * Comment for Unit
+             */
+            export type Unit = undefined;"
+            }
+        );
+    } else {
+        assert_eq!(
+            Unit::DECL,
+            indoc! {"
+            /**
+             * Comment for Unit
+             */
+            export type Unit = null;"
+            }
+        );
+    };
+}
+
+#[test]
+fn test_named_fields() {
+    /// Comment for Struct
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct A {
+        /// Comment for a
+        a: (usize, u64),
+        /// Comment for b
+        b: HashMap<String, i128>,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {"
+            /**
+             * Comment for Struct
+             */
+            export type A = {
+                /**
+                 * Comment for a
+                 */
+                a: [number, number];
+                /**
+                 * Comment for b
+                 */
+                b: Map<string, bigint>;
+            };"
+        }
+    } else {
+        indoc! {"
+            /**
+             * Comment for Struct
+             */
+            export type A = {
+                /**
+                 * Comment for a
+                 */
+                a: [number, number];
+                /**
+                 * Comment for b
+                 */
+                b: Record<string, number>;
+            };"
+        }
+    };
+
+    assert_eq!(A::DECL, expected);
+}
+
+#[test]
+fn test_newtype_struct() {
+    /// Comment for Newtype
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Newtype(i32);
+
+    assert_eq!(
+        Newtype::DECL,
+        indoc! {"
+        /**
+         * Comment for Newtype
+         */
+        export type Newtype = number;"
+        }
+    );
+}
+
+#[test]
+fn test_tuple_struct() {
+    /// Comment for Tuple
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Tuple(i32, String);
+    /// Comment for EmptyTuple
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct EmptyTuple();
+
+    assert_eq!(
+        Tuple::DECL,
+        indoc! {"
+        /**
+         * Comment for Tuple
+         */
+        export type Tuple = [number, string];"
+        }
+    );
+    assert_eq!(
+        EmptyTuple::DECL,
+        indoc! {"
+        /**
+         * Comment for EmptyTuple
+         */
+        export type EmptyTuple = [];"
+        }
+    );
+}
+
+#[test]
+fn test_nested_struct() {
+    /// Comment for A
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct A {
+        /// Comment for x
+        x: f64,
+    }
+
+    /// Comment for B
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct B {
+        /// Comment for a
+        a: A,
+    }
+
+    assert_eq!(
+        B::DECL,
+        indoc! {"
+            /**
+             * Comment for B
+             */
+            export type B = {
+                /**
+                 * Comment for a
+                 */
+                a: A;
+            };"
+        }
+    );
+}
+
+#[test]
+fn test_struct_with_borrowed_fields() {
+    use std::borrow::Cow;
+
+    /// Comment for Borrow
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    struct Borrow<'a> {
+        /// Comment for raw
+        raw: &'a str,
+        /// Comment for cow
+        cow: Cow<'a, str>,
+    }
+
+    assert_eq!(
+        Borrow::DECL,
+        indoc! {"
+            /**
+             * Comment for Borrow
+             */
+            export type Borrow = {
+                /**
+                 * Comment for raw
+                 */
+                raw: string;
+                /**
+                 * Comment for cow
+                 */
+                cow: string;
+            };"
+        }
+    );
+}
+
+#[test]
+fn test_tagged_struct() {
+    /// Comment for TaggedStruct
+    #[derive(Tsify)]
+    #[tsify(type_alias)]
+    #[serde(tag = "type")]
+    struct TaggedStruct {
+        /// Comment for x
+        x: i32,
+        /// Comment for y
+        y: i32,
+    }
+
+    assert_eq!(
+        TaggedStruct::DECL,
+        indoc! {r#"
+            /**
+             * Comment for TaggedStruct
+             */
+            export type TaggedStruct = {
+                type: "TaggedStruct";
+                /**
+                 * Comment for x
+                 */
+                x: number;
+                /**
+                 * Comment for y
+                 */
+                y: number;
+            };"#
+        }
+    );
+}

--- a/tests/type_override.rs
+++ b/tests/type_override.rs
@@ -88,7 +88,13 @@ fn test_enum_with_type_override() {
          */
         export type Enum = {
             Struct: {
+                /**
+                 * Comment for x
+                 */
                 x: `tpl_lit_${string}`;
+                /**
+                 * Comment for y
+                 */
                 y: 0 | 1 | 2;
             };
         } | {

--- a/tests/type_override.rs
+++ b/tests/type_override.rs
@@ -86,7 +86,16 @@ fn test_enum_with_type_override() {
         /**
          * Comment for Enum
          */
-        export type Enum = { Struct: { x: `tpl_lit_${string}`; y: 0 | 1 | 2 } } | { Tuple: [`tpl_lit_${string}`, 0 | 1 | 2] } | { Newtype: number };"#
+        export type Enum = {
+            Struct: {
+                x: `tpl_lit_${string}`;
+                y: 0 | 1 | 2;
+            };
+        } | {
+            Tuple: [`tpl_lit_${string}`, 0 | 1 | 2];
+        } | {
+            Newtype: number;
+        };"#
     };
 
     assert_eq!(Enum::DECL, expected);

--- a/tests/value_enum.rs
+++ b/tests/value_enum.rs
@@ -1,0 +1,109 @@
+#![allow(dead_code)]
+
+use indoc::indoc;
+use pretty_assertions::assert_eq;
+use tsify::Tsify;
+
+#[test]
+fn value_enum() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(value_enum)]
+    enum External {
+        /// Comment for Struct
+        Alpha,
+        /// Comment for EmptyStruct
+        Beta,
+        /// Comment for Tuple
+        Gamma,
+    }
+
+    let expected = indoc! {r#"
+        export enum External {
+            /**
+             * Comment for Struct
+             */
+            Alpha = "Alpha",
+            /**
+             * Comment for EmptyStruct
+             */
+            Beta = "Beta",
+            /**
+             * Comment for Tuple
+             */
+            Gamma = "Gamma",
+        }"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn value_enum_renamed() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[serde(rename_all = "kebab-case")]
+    #[tsify(value_enum)]
+    enum External {
+        /// Comment for Struct
+        Alpha,
+        /// Comment for EmptyStruct
+        Beta,
+        /// Comment for Tuple
+        GammaDelta,
+    }
+
+    let expected = indoc! {r#"
+        export enum External {
+            /**
+             * Comment for Struct
+             */
+            alpha = "alpha",
+            /**
+             * Comment for EmptyStruct
+             */
+            beta = "beta",
+            /**
+             * Comment for Tuple
+             */
+            "gamma-delta" = "gamma-delta",
+        }"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}
+
+#[test]
+fn value_enum_renamed_variants() {
+    /// Comment for External
+    #[derive(Tsify)]
+    #[tsify(value_enum, rename_variants)]
+    #[serde(rename_all = "kebab-case")]
+    enum External {
+        /// Comment for Struct
+        Alpha,
+        /// Comment for EmptyStruct
+        Beta,
+        /// Comment for Tuple
+        GammaDelta,
+    }
+
+    let expected = indoc! {r#"
+        export enum External {
+            /**
+             * Comment for Struct
+             */
+            Alpha = "alpha",
+            /**
+             * Comment for EmptyStruct
+             */
+            Beta = "beta",
+            /**
+             * Comment for Tuple
+             */
+            GammaDelta = "gamma-delta",
+        }"#
+    };
+
+    assert_eq!(External::DECL, expected);
+}

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -8,6 +8,8 @@ use serde_derive_internals::attr::{Container, TagType};
 pub struct TsifyContainerAttrs {
     pub type_override: Option<String>,
     pub type_params: Option<Vec<String>>,
+    /// Whether to prefer type aliases over interfaces.
+    pub type_alias: bool,
     /// Implement `IntoWasmAbi` for the type.
     pub into_wasm_abi: bool,
     /// Implement `FromWasmAbi` for the type.
@@ -98,6 +100,14 @@ impl TsifyContainerAttrs {
                     }
                     let lit = meta.value()?.parse::<syn::LitStr>()?;
                     attrs.type_params = Some(lit.value().split(',').map(|s| s.trim().to_string()).collect());
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("type_alias") {
+                    if attrs.type_alias {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    attrs.type_alias = true;
                     return Ok(());
                 }
 
@@ -257,7 +267,7 @@ impl TsifyContainerAttrs {
                     return Ok(());
                 }
 
-                Err(meta.error("unsupported tsify attribute, expected one of `type`, `type_params`, `into_wasm_abi`, `from_wasm_abi`, `rename_variant`, namespace`, `discriminants`, `value_enum`, `type_prefix`, `type_suffix`, `missing_as_null`, `hashmap_as_object`, `large_number_types_as_bigints`"))
+                Err(meta.error("unsupported tsify attribute, expected one of `type`, `type_params`, `type_alias`, `into_wasm_abi`, `from_wasm_abi`, `namespace`, `discriminants`, `rename_variants`, `value_enum`, `type_prefix`, `type_suffix`, `missing_as_null`, `hashmap_as_object`, `large_number_types_as_bigints`"))
             })?;
         }
 

--- a/tsify-macros/src/comments.rs
+++ b/tsify-macros/src/comments.rs
@@ -2,14 +2,12 @@ use proc_macro2::TokenTree;
 use quote::ToTokens;
 use syn::LitStr;
 
-use crate::typescript::TsType;
-
 /// Extract the documentation comments from a Vec of attributes
 pub fn extract_doc_comments(attrs: &[syn::Attribute]) -> Vec<String> {
     attrs
         .iter()
         .filter_map(|a| {
-            // if the path segments include an ident of "doc" we know this
+            // if the path segments include an ident of "doc" we know
             // this is a doc comment
             if a.path().segments.iter().any(|s| s.ident == "doc") {
                 Some(a.to_token_stream().into_iter().filter_map(|t| match t {
@@ -63,15 +61,4 @@ pub fn write_doc_comments(
         .join("");
 
     write!(f, "{}", format_args!("/**\n{} */\n", comment))
-}
-
-/// Remove all comments from a `TsType::TypeLit`
-pub fn clean_comments(typ: &mut TsType) {
-    if let TsType::TypeLit(ref mut lit) = typ {
-        lit.members.iter_mut().for_each(|elem| {
-            elem.comments = vec![];
-            // Recurse
-            clean_comments(&mut elem.type_ann);
-        });
-    }
 }

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -20,7 +20,8 @@ pub struct Container<'a> {
 impl<'a> Container<'a> {
     pub fn new(serde_container: SerdeContainer<'a>) -> Self {
         let input = &serde_container.original;
-        let attrs = TsifyContainerAttrs::from_derive_input(input);
+        let container = &serde_container.attrs;
+        let attrs = TsifyContainerAttrs::from_derive_input(input, container);
         let errors = ErrorTracker::new();
 
         let attrs = match attrs {

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -277,9 +277,25 @@ impl Display for TsEnumDecl {
                 self.members
                     .iter()
                     .map(|member| {
-                        let mut clone = member.type_ann.clone();
-                        clean_comments(&mut clone);
-                        clone
+                        // TODO remove this once type_alias are properly formatted
+                        let mut clone = member.clone();
+                        clean_comments(&mut clone.type_ann);
+
+                        if self.namespace {
+                            let name = if clone.type_params.is_empty() {
+                                format!("{}.{}", self.id, clone.id)
+                            } else {
+                                let type_params = clone.type_params.join(", ");
+                                format!("{}.{}<{}>", self.id, clone.id, type_params)
+                            };
+
+                            TsType::Ref {
+                                name,
+                                type_params: vec![],
+                            }
+                        } else {
+                            clone.type_ann.clone()
+                        }
                     })
                     .collect(),
             ),

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -1,4 +1,3 @@
-use crate::comments::clean_comments;
 use crate::typescript::ToStringWithIndent;
 use crate::{
     comments::write_doc_comments,
@@ -277,16 +276,12 @@ impl Display for TsEnumDecl {
                 self.members
                     .iter()
                     .map(|member| {
-                        // TODO remove this once type_alias are properly formatted
-                        let mut clone = member.clone();
-                        clean_comments(&mut clone.type_ann);
-
                         if self.namespace {
-                            let name = if clone.type_params.is_empty() {
-                                format!("{}.{}", self.id, clone.id)
+                            let name = if member.type_params.is_empty() {
+                                format!("{}.{}", self.id, member.id)
                             } else {
-                                let type_params = clone.type_params.join(", ");
-                                format!("{}.{}<{}>", self.id, clone.id, type_params)
+                                let type_params = member.type_params.join(", ");
+                                format!("{}.{}<{}>", self.id, member.id, type_params)
                             };
 
                             TsType::Ref {
@@ -294,7 +289,7 @@ impl Display for TsEnumDecl {
                                 type_params: vec![],
                             }
                         } else {
-                            clone.type_ann.clone()
+                            member.type_ann.clone()
                         }
                     })
                     .collect(),

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -65,18 +65,8 @@ impl Display for TsInterfaceDecl {
             write!(f, " extends {extends}")?;
         }
 
-        if self.body.is_empty() {
-            write!(f, " {{}}")
-        } else {
-            let members = self
-                .body
-                .iter()
-                .map(|elem| format!("\n{};", elem.to_string_with_indent(4)))
-                .collect::<Vec<_>>()
-                .join("");
-
-            write!(f, " {{{members}\n}}")
-        }
+        write!(f, " ")?;
+        TsTypeLit::from(self.body.as_slice()).fmt(f)
     }
 }
 

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -285,7 +285,7 @@ impl<'a> Parser<'a> {
 
     fn parse_value_enum(&self, variants: &[Variant]) -> Decl {
         let members = variants
-            .into_iter()
+            .iter()
             .filter(|v| !v.attrs.skip_serializing() && !v.attrs.skip_deserializing())
             .map(|variant| {
                 let variant_serialized = variant.attrs.name().serialize_name();
@@ -314,7 +314,7 @@ impl<'a> Parser<'a> {
         let mut discriminants = self.container.attrs.discriminants.to_enum_decl();
 
         let members = variants
-            .into_iter()
+            .iter()
             .filter(|v| !v.attrs.skip_serializing() && !v.attrs.skip_deserializing())
             .map(|variant| {
                 let variant_serialized = variant.attrs.name().serialize_name();

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -105,7 +105,7 @@ impl<'a> Parser<'a> {
 
     fn create_decl(&self, members: Vec<TsTypeElement>, extends: Vec<TsType>) -> Decl {
         // An interface can only extend an identifier/qualified-name with optional type arguments.
-        if extends.iter().all(|ty| ty.is_ref()) {
+        if !self.container.attrs.type_alias && extends.iter().all(|ty| ty.is_ref()) {
             let mut type_ref_names: HashSet<&String> = HashSet::new();
             members.iter().for_each(|member| {
                 type_ref_names.extend(member.type_ann.type_ref_names());

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::{attrs::TypeGenerationConfig, comments::write_doc_comments};
 
-use super::TsType;
+use super::{ToStringWithIndent, TsType};
 
 /// Built-in TypeScript types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -33,18 +33,18 @@ pub enum TsTypeElementKey {
     Var(String),
 }
 
-impl Into<TsType> for TsTypeElementKey {
-    fn into(self) -> TsType {
-        match self {
+impl From<TsTypeElementKey> for TsType {
+    fn from(value: TsTypeElementKey) -> Self {
+        match value {
             TsTypeElementKey::Lit(s) => TsType::Lit(s),
             TsTypeElementKey::Var(v) => TsType::Computed(v),
         }
     }
 }
 
-impl Into<TsTypeElementKey> for String {
-    fn into(self) -> TsTypeElementKey {
-        TsTypeElementKey::Lit(self)
+impl From<String> for TsTypeElementKey {
+    fn from(value: String) -> Self {
+        TsTypeElementKey::Lit(value)
     }
 }
 

--- a/tsify-macros/src/typescript/basic.rs
+++ b/tsify-macros/src/typescript/basic.rs
@@ -94,6 +94,14 @@ impl From<TsTypeElement> for TsTypeLit {
     }
 }
 
+impl From<&[TsTypeElement]> for TsTypeLit {
+    fn from(m: &[TsTypeElement]) -> Self {
+        TsTypeLit {
+            members: m.to_vec(),
+        }
+    }
+}
+
 impl From<TsTypeElement> for TsType {
     fn from(m: TsTypeElement) -> Self {
         TsType::TypeLit(m.into())
@@ -138,17 +146,17 @@ impl From<TsTypeLit> for TsType {
 
 impl Display for TsTypeLit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let members = self
-            .members
-            .iter()
-            .map(|elem| elem.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-
-        if members.is_empty() {
+        if self.members.is_empty() {
             write!(f, "{{}}")
         } else {
-            write!(f, "{{ {members} }}")
+            let members = self
+                .members
+                .iter()
+                .map(|elem| format!("\n{};", elem.to_string_with_indent(4)))
+                .collect::<Vec<_>>()
+                .join("");
+
+            write!(f, "{{{members}\n}}")
         }
     }
 }

--- a/tsify-macros/src/typescript/mod.rs
+++ b/tsify-macros/src/typescript/mod.rs
@@ -1,7 +1,9 @@
 mod basic;
+mod to_string_with_indent;
 mod ts_type;
 mod ts_type_display;
 mod ts_type_from_name;
 
 pub use basic::*;
+pub use to_string_with_indent::*;
 pub use ts_type::*;

--- a/tsify-macros/src/typescript/to_string_with_indent.rs
+++ b/tsify-macros/src/typescript/to_string_with_indent.rs
@@ -1,0 +1,14 @@
+pub trait ToStringWithIndent {
+    fn to_string_with_indent(&self, indent: usize) -> String;
+}
+
+impl<T: ToString> ToStringWithIndent for T {
+    fn to_string_with_indent(&self, indent: usize) -> String {
+        let out = self.to_string();
+        let indent_str = " ".repeat(indent);
+        out.split('\n')
+            .map(|line| format!("{}{}", indent_str, line))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}

--- a/tsify-macros/src/typescript/ts_type.rs
+++ b/tsify-macros/src/typescript/ts_type.rs
@@ -325,7 +325,6 @@ impl TsType {
                 tys.iter().for_each(|t| t.visit(f));
             }
             TsType::Keyword(_) | TsType::Lit(_) | TsType::Computed(_) | TsType::Override { .. } => {
-                ()
             }
         }
     }

--- a/tsify-macros/src/typescript/ts_type.test.rs
+++ b/tsify-macros/src/typescript/ts_type.test.rs
@@ -41,7 +41,7 @@ fn test_basic_types() {
     assert_ts!(config, Vec<i32> | VecDeque<i32> | LinkedList<i32> | &'a [i32], "number[]");
     assert_ts!(config, HashSet<i32> | BTreeSet<i32>, "number[]");
 
-    assert_ts!(config, Result<i32, String>, "{ Ok: number } | { Err: string }");
+    assert_ts!(config, Result<i32, String>, "{\n    Ok: number;\n} | {\n    Err: string;\n}");
     assert_ts!(config, dyn Fn(String, f64) | dyn FnOnce(String, f64) | dyn FnMut(String, f64), "(arg0: string, arg1: number) => void");
     assert_ts!(config, dyn Fn(String) -> i32 | dyn FnOnce(String) -> i32 | dyn FnMut(String) -> i32, "(arg0: string) => number");
 
@@ -57,22 +57,22 @@ fn test_basic_types() {
     assert_ts!(config, [i32; 17], "number[]");
     assert_ts!(config, [i32; 1 + 1], "number[]");
 
-    assert_ts!(config, Duration, "{ secs: number; nanos: number }");
+    assert_ts!(config, Duration, "{\n    secs: number;\n    nanos: number;\n}");
     assert_ts!(
         config,
         SystemTime,
-        "{ secs_since_epoch: number; nanos_since_epoch: number }"
+        "{\n    secs_since_epoch: number;\n    nanos_since_epoch: number;\n}"
     );
 
-    assert_ts!(config, Range<i32>, "{ start: number; end: number }");
+    assert_ts!(config, Range<i32>, "{\n    start: number;\n    end: number;\n}");
     assert_ts!(
         config,
         Range<&'static str>,
-        "{ start: string; end: string }"
+        "{\n    start: string;\n    end: string;\n}"
     );
     assert_ts!(
         config,
         RangeInclusive<usize>,
-        "{ start: number; end: number }"
+        "{\n    start: number;\n    end: number;\n}"
     );
 }

--- a/tsify-macros/src/typescript/ts_type.test.rs
+++ b/tsify-macros/src/typescript/ts_type.test.rs
@@ -57,14 +57,22 @@ fn test_basic_types() {
     assert_ts!(config, [i32; 17], "number[]");
     assert_ts!(config, [i32; 1 + 1], "number[]");
 
-    assert_ts!(config, Duration, "{\n    secs: number;\n    nanos: number;\n}");
+    assert_ts!(
+        config,
+        Duration,
+        "{\n    secs: number;\n    nanos: number;\n}"
+    );
     assert_ts!(
         config,
         SystemTime,
         "{\n    secs_since_epoch: number;\n    nanos_since_epoch: number;\n}"
     );
 
-    assert_ts!(config, Range<i32>, "{\n    start: number;\n    end: number;\n}");
+    assert_ts!(
+        config,
+        Range<i32>,
+        "{\n    start: number;\n    end: number;\n}"
+    );
     assert_ts!(
         config,
         Range<&'static str>,

--- a/tsify-macros/src/typescript/ts_type_display.rs
+++ b/tsify-macros/src/typescript/ts_type_display.rs
@@ -14,6 +14,10 @@ impl Display for TsType {
                 write!(f, "\"{lit}\"")
             }
 
+            TsType::Computed(comp) => {
+                write!(f, "{comp}")
+            }
+
             TsType::Array(elem) => match elem.as_ref() {
                 TsType::Union(_) | TsType::Intersection(_) | &TsType::Option(_, _) => {
                     write!(f, "({elem})[]")

--- a/tsify-macros/src/typescript/ts_type_from_name.rs
+++ b/tsify-macros/src/typescript/ts_type_from_name.rs
@@ -10,7 +10,7 @@ macro_rules! type_lit {
         TsType::TypeLit(TsTypeLit {
             members: vec![$(
                 TsTypeElement {
-                    key: stringify!($k).to_string(),
+                    key: stringify!($k).to_string().into(),
                     type_ann: $t,
                     optional: false,
                     comments: vec![],


### PR DESCRIPTION
A super-PR with all the changes from #77 #78 #79 merged into one big PR. See the individual PRs for more details.

Altogether it allows you to define much more powerful sum types like this, while keeping a very clean API on the Typescript side. Additionaly, you can generate TypeScript enums from Rust which you couldn't generate before at all (only types)

Closes https://github.com/madonoharu/tsify/pull/77
Closes https://github.com/madonoharu/tsify/pull/78
Closes https://github.com/madonoharu/tsify/pull/79
