### PR TITLE
feat: add From<Ts<T>> for JsValue

### DIFF
--- a/src/ts.rs
+++ b/src/ts.rs
@@ -106,6 +106,12 @@ where
     }
 }
 
+impl <T: Tsify> From<Ts<T>> for JsValue {
+    fn from(value: Ts<T>) -> Self {
+        value.js_value()
+    }
+}
+
 impl<T: Tsify> fmt::Debug for Ts<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Ts").finish()

--- a/src/ts.rs
+++ b/src/ts.rs
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl <T: Tsify> From<Ts<T>> for JsValue {
+impl<T: Tsify> From<Ts<T>> for JsValue {
     fn from(value: Ts<T>) -> Self {
         value.js_value()
     }

--- a/tests-e2e/reference_output/test6/test6.d.ts
+++ b/tests-e2e/reference_output/test6/test6.d.ts
@@ -16,4 +16,10 @@ export function accept_point_vec(point: Point[]): void;
 
 export function return_point(point: Point): Point;
 
+export function return_point_async(point: Point): Promise<Point>;
+
+export function return_point_option_async(point: Point): Promise<Point | undefined>;
+
+export function return_point_result_async(point: Point): Promise<Point>;
+
 export function return_point_vec(): Point[];

--- a/tests-e2e/test6/entry_point.rs
+++ b/tests-e2e/test6/entry_point.rs
@@ -41,6 +41,23 @@ pub fn return_point(point: &Ts<Point>) -> Ts<Point> {
 #[wasm_bindgen]
 pub async fn accept_point_ref_async(point: &Ts<Point>) {}
 
+// Async fns return through `IntoJsResult`; the bare, `Result`, and `Option`
+// shapes below each require `Ts<T>: Into<JsValue>` via a distinct impl path.
+#[wasm_bindgen]
+pub async fn return_point_async(point: &Ts<Point>) -> Ts<Point> {
+    point.clone()
+}
+
+#[wasm_bindgen]
+pub async fn return_point_result_async(point: Ts<Point>) -> Result<Ts<Point>, JsError> {
+    Ok(point)
+}
+
+#[wasm_bindgen]
+pub async fn return_point_option_async(point: &Ts<Point>) -> Option<Ts<Point>> {
+    Some(point.clone())
+}
+
 #[wasm_bindgen]
 pub fn accept_point_vec(point: Vec<Ts<Point>>) {}
 


### PR DESCRIPTION
This fixes an issue where async fns cannot be compiled with `#[wasm_bindgen]`.