### PR TITLE
Fix expand tests and harden the scheduled workflows

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -2,8 +2,8 @@ name: Setup test environment
 description: >
     Everything ./test.sh needs (Node.js, stable Rust, wasm-pack,
     cargo-expand), plus a fresh dependency resolution: Cargo.lock is
-    gitignored, so generating it here pins this run to the latest compatible
-    versions — the configuration downstream users actually get.
+    gitignored, so every run resolves the latest compatible versions —
+    what downstream users actually get.
 
 outputs:
     wasm-bindgen-version:

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -18,13 +18,11 @@ runs:
           with:
               node-version: "24"
 
+        # rustup ships on the runner; the archived actions-rs/toolchain action
+        # (node12) only wrapped these same rustup calls.
         - name: Install toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-              profile: minimal
-              toolchain: stable
-              override: true
-              components: rustfmt
+          shell: bash
+          run: rustup toolchain install stable --profile minimal --component rustfmt --override
 
         - name: Install wasm-pack
           uses: jetli/wasm-pack-action@v0.4.0
@@ -47,5 +45,7 @@ runs:
               WB_VERSION="$(cargo pkgid wasm-bindgen)"
               WB_VERSION="${WB_VERSION##*@}"
               echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
-              echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
-              rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
+              {
+                echo "Resolved wasm-bindgen: $WB_VERSION"
+                rustc --version
+              } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -1,0 +1,51 @@
+name: Setup test environment
+description: >
+    Everything ./test.sh needs (Node.js, stable Rust, wasm-pack,
+    cargo-expand), plus a fresh dependency resolution: Cargo.lock is
+    gitignored, so generating it here pins this run to the latest compatible
+    versions — the configuration downstream users actually get.
+
+outputs:
+    wasm-bindgen-version:
+        description: The wasm-bindgen version this run resolved.
+        value: ${{ steps.resolve.outputs.wasm_bindgen }}
+
+runs:
+    using: composite
+    steps:
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+              node-version: "24"
+
+        - name: Install toolchain
+          uses: actions-rs/toolchain@v1
+          with:
+              profile: minimal
+              toolchain: stable
+              override: true
+              components: rustfmt
+
+        - name: Install wasm-pack
+          uses: jetli/wasm-pack-action@v0.4.0
+          with:
+              # specify exact version to work around
+              # https://github.com/jetli/wasm-pack-action/issues/23
+              version: v0.14.0
+
+        - name: Add cargo-expand
+          shell: bash
+          run: cargo install cargo-expand
+
+        # Log the resolved wasm-bindgen version so failures can be attributed
+        # to a dependency release vs. a toolchain change.
+        - name: Resolve dependencies
+          id: resolve
+          shell: bash
+          run: |
+              cargo generate-lockfile
+              WB_VERSION="$(cargo pkgid wasm-bindgen)"
+              WB_VERSION="${WB_VERSION##*@}"
+              echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
+              echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
+              rustc --version | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/track-failure-issue/action.yml
+++ b/.github/actions/track-failure-issue/action.yml
@@ -1,0 +1,54 @@
+name: Track failure via issue
+description: >
+    A red run in the Actions tab notifies no one (75 consecutive failures
+    went unnoticed in 2026). Instead, `mode: notify` opens a tracking issue
+    on failure — once per breakage, deduped by exact title — and
+    `mode: close` closes it again on the next success, so the alert re-arms
+    instead of staying muted forever.
+
+inputs:
+    mode:
+        description: '"notify" (open unless one exists) or "close" (close if open).'
+        required: true
+    title:
+        description: Exact issue title. Both modes search for this string, so it must not vary between them.
+        required: true
+    body:
+        description: Issue body (notify mode only).
+        required: false
+        default: ""
+    github-token:
+        description: Token with issues write access.
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Find, open, or close the tracking issue
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.github-token }}
+              MODE: ${{ inputs.mode }}
+              ISSUE_TITLE: ${{ inputs.title }}
+              ISSUE_BODY: ${{ inputs.body }}
+              RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          run: |
+              EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
+              case "$MODE" in
+                notify)
+                  if [ -n "$EXISTING" ]; then
+                    echo "Tracking issue #$EXISTING already open; not filing another."
+                  else
+                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
+                    gh issue create --title "$ISSUE_TITLE" --label ci-failure --assignee madonoharu --body "$ISSUE_BODY"
+                  fi
+                  ;;
+                close)
+                  if [ -n "$EXISTING" ]; then
+                    gh issue close "$EXISTING" --comment "Resolved by a successful run: $RUN_URL"
+                  fi
+                  ;;
+                *)
+                  echo "::error::unknown mode: $MODE" && exit 1
+                  ;;
+              esac

--- a/.github/actions/track-failure-issue/action.yml
+++ b/.github/actions/track-failure-issue/action.yml
@@ -33,13 +33,16 @@ runs:
               ISSUE_BODY: ${{ inputs.body }}
               RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           run: |
-              EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
+              # `in:title` matches substrings, so filter to an exact title
+              # match client-side (gh's --jq exposes the environment as `env`).
+              EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --limit 100 --json number,title --jq 'map(select(.title == env.ISSUE_TITLE))[0].number')
               case "$MODE" in
                 notify)
                   if [ -n "$EXISTING" ]; then
                     echo "Tracking issue #$EXISTING already open; not filing another."
                   else
-                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
+                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" --force \
+                      || echo "::warning::ci-failure label could not be created or updated"
                     gh issue create --title "$ISSUE_TITLE" --label ci-failure --assignee madonoharu --body "$ISSUE_BODY"
                   fi
                   ;;

--- a/.github/actions/track-failure-issue/action.yml
+++ b/.github/actions/track-failure-issue/action.yml
@@ -3,15 +3,15 @@ description: >
     A red run in the Actions tab notifies no one (75 consecutive failures
     went unnoticed in 2026). Instead, `mode: notify` opens a tracking issue
     on failure — once per breakage, deduped by exact title — and
-    `mode: close` closes it again on the next success, so the alert re-arms
-    instead of staying muted forever.
+    `mode: close` closes it on the next success, re-arming the alert: one
+    left open would mute every later breakage.
 
 inputs:
     mode:
         description: '"notify" (open unless one exists) or "close" (close if open).'
         required: true
     title:
-        description: Exact issue title. Both modes search for this string, so it must not vary between them.
+        description: Exact issue title. Both modes must search for the exact same string, or a stale issue would mute all future alerts.
         required: true
     body:
         description: Issue body (notify mode only).

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -98,12 +98,38 @@ jobs:
                     git add tests
                     git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.deps.outputs.wasm_bindgen }}"
                     git push --force --set-upstream origin update-expanded-test-artifacts
-                    gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" 2>/dev/null || true
-                    gh pr create --fill --assignee madonoharu --label automated-pr \
-                      || echo "PR already exists; the branch push above updated it."
+                    # Check for an existing PR explicitly instead of catching
+                    # `gh pr create` errors: a catch-all would also swallow real
+                    # failures (missing label, 403 from repo settings, ...) and
+                    # report success with a misleading message.
+                    EXISTING_PR=$(gh pr list --head update-expanded-test-artifacts --state open --json number --jq '.[0].number')
+                    if [ -n "$EXISTING_PR" ]; then
+                      echo "PR #$EXISTING_PR already open; the push above updated it."
+                    else
+                      gh pr create --fill
+                      # Assignee/label are decoration; apply after creation so
+                      # their failure cannot prevent the PR itself.
+                      gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" 2>/dev/null || true
+                      gh pr edit --add-assignee madonoharu --add-label automated-pr \
+                        || echo "::warning::PR created but assignee/label could not be applied"
+                    fi
                   }
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            # Counterpart of "Notify on failure": once a run succeeds again,
+            # close the tracking issue so the next real breakage can notify
+            # again (an issue that stays open would mute all future alerts).
+            - name: Close failure tracking issue on success
+              if: success()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TITLE="CI: nightly wasm-bindgen expand check is failing"
+                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  if [ -n "$EXISTING" ]; then
+                    gh issue close "$EXISTING" --comment "Resolved by a successful run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  fi
 
             # A red run in the Actions tab notifies no one; 75 consecutive
             # failures went unnoticed in 2026. Open a tracking issue instead

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -26,6 +26,12 @@ jobs:
         name: Create Test Artifacts
         runs-on: ubuntu-latest
 
+        # Single source of truth for the tracking-issue title: "Notify on
+        # failure" and its "Close ... on success" counterpart must search for
+        # the exact same string, or a stale issue would mute all future alerts.
+        env:
+            ISSUE_TITLE: "CI: nightly wasm-bindgen expand check is failing"
+
         steps:
             - name: Checkout sources
               uses: actions/checkout@v6
@@ -93,40 +99,43 @@ jobs:
 
             - name: Check for changes
               run: |
-                  git diff --quiet -- tests || {
-                    echo "Creating PR with changes..."
-                    git add tests
-                    git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.deps.outputs.wasm_bindgen }}"
-                    git push --force --set-upstream origin update-expanded-test-artifacts
-                    # Check for an existing PR explicitly instead of catching
-                    # `gh pr create` errors: a catch-all would also swallow real
-                    # failures (missing label, 403 from repo settings, ...) and
-                    # report success with a misleading message.
-                    EXISTING_PR=$(gh pr list --head update-expanded-test-artifacts --state open --json number --jq '.[0].number')
-                    if [ -n "$EXISTING_PR" ]; then
-                      echo "PR #$EXISTING_PR already open; the push above updated it."
-                    else
-                      gh pr create --fill
-                      # Assignee/label are decoration; apply after creation so
-                      # their failure cannot prevent the PR itself.
-                      gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" 2>/dev/null || true
-                      gh pr edit --add-assignee madonoharu --add-label automated-pr \
-                        || echo "::warning::PR created but assignee/label could not be applied"
-                    fi
-                  }
+                  if git diff --quiet -- tests; then
+                    echo "Expanded test artifacts are unchanged; nothing to do."
+                    exit 0
+                  fi
+
+                  echo "Creating PR with changes..."
+                  git add tests
+                  git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.deps.outputs.wasm_bindgen }}"
+                  git push --force --set-upstream origin update-expanded-test-artifacts
+
+                  # Check for an existing PR explicitly instead of catching
+                  # `gh pr create` errors: a catch-all would swallow real
+                  # failures too (missing label, 403 from repo settings, ...)
+                  # and report them as success.
+                  EXISTING_PR=$(gh pr list --head update-expanded-test-artifacts --state open --json number --jq '.[0].number')
+                  if [ -n "$EXISTING_PR" ]; then
+                    echo "PR #$EXISTING_PR already open; the push above updated it."
+                    exit 0
+                  fi
+
+                  gh pr create --fill
+                  # Assignee/label are decoration; apply after creation so
+                  # a failure there cannot block the PR itself.
+                  gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" 2>/dev/null || true
+                  gh pr edit --add-assignee madonoharu --add-label automated-pr \
+                    || echo "::warning::PR created but assignee/label could not be applied"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            # Counterpart of "Notify on failure": once a run succeeds again,
-            # close the tracking issue so the next real breakage can notify
-            # again (an issue that stays open would mute all future alerts).
+            # Counterpart of "Notify on failure": closing the issue on success
+            # re-arms the alert — one left open would mute every later breakage.
             - name: Close failure tracking issue on success
               if: success()
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  TITLE="CI: nightly wasm-bindgen expand check is failing"
-                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
                   if [ -n "$EXISTING" ]; then
                     gh issue close "$EXISTING" --comment "Resolved by a successful run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   fi
@@ -139,16 +148,15 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  TITLE="CI: nightly wasm-bindgen expand check is failing"
-                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
                   if [ -z "$EXISTING" ]; then
                     gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
-                    gh issue create --title "$TITLE" --label ci-failure --assignee madonoharu --body "The scheduled expand check failed.
+                    gh issue create --title "$ISSUE_TITLE" --label ci-failure --assignee madonoharu --body "The scheduled expand check failed.
 
                   Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                   Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
 
-                  This usually means either a new wasm-bindgen release changed the macro output in a way that broke expansion, or a toolchain change altered \`-Zunpretty=expanded\` behavior. See CONTRIBUTING.md for how to regenerate the snapshots."
+                  Likely causes: a new wasm-bindgen release whose changed macro output breaks expansion, or a toolchain change that altered \`-Zunpretty=expanded\` behavior. See CONTRIBUTING.md for how to regenerate the snapshots."
                   else
                     echo "Tracking issue #$EXISTING already open; not filing another."
                   fi

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -67,7 +67,8 @@ jobs:
               id: deps
               run: |
                   cargo generate-lockfile
-                  WB_VERSION=$(grep -A 1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | cut -d'"' -f2)
+                  WB_VERSION="$(cargo pkgid wasm-bindgen)"
+                  WB_VERSION="${WB_VERSION##*@}"
                   echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
                   echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
                   rustc --version | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -4,6 +4,9 @@ name: Check wasm-bindgen changes
 # This cron job is meant to create a PR whenever there are changes to the expanded macro output.
 # Since all PRs that affect tsify's macro output should update their own tests, this should only detect
 # changes in other rust crates.
+#
+# If this job fails (e.g. the expansion itself errors out), it opens a tracking
+# issue so the failure is not silently lost in the Actions tab.
 
 on:
     schedule:
@@ -12,6 +15,11 @@ on:
 
 env:
     TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+
+permissions:
+    contents: write
+    pull-requests: write
+    issues: write
 
 jobs:
     test:
@@ -45,6 +53,19 @@ jobs:
             - name: Add cargo-expand
               run: cargo install cargo-expand
 
+            # The expansion snapshots track the *latest* wasm-bindgen release
+            # (Cargo.lock is gitignored, so this resolves fresh every run).
+            # Log the resolved version so failures can be attributed to a
+            # dependency release vs. a toolchain change.
+            - name: Resolve dependencies
+              id: deps
+              run: |
+                  cargo generate-lockfile
+                  WB_VERSION=$(grep -A 1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | cut -d'"' -f2)
+                  echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
+                  rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
+
             - name: Setup git config
               run: |
                   git config user.name "${{ github.actor }} via GitHub Actions"
@@ -72,16 +93,36 @@ jobs:
 
             - name: Check for changes
               run: |
-                  git diff --quiet || {
-                    echo "Available branches:"
-                    git branch -a
-                    echo "Remote configuration:"
-                    git remote -v
+                  git diff --quiet -- tests || {
                     echo "Creating PR with changes..."
                     git add tests
-                    git commit -m "Update expanded test artifacts"
+                    git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.deps.outputs.wasm_bindgen }}"
                     git push --force --set-upstream origin update-expanded-test-artifacts
-                    gh pr create --fill
+                    gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" 2>/dev/null || true
+                    gh pr create --fill --assignee madonoharu --label automated-pr \
+                      || echo "PR already exists; the branch push above updated it."
                   }
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            # A red run in the Actions tab notifies no one; 75 consecutive
+            # failures went unnoticed in 2026. Open a tracking issue instead
+            # (only once per breakage: skipped while one is already open).
+            - name: Notify on failure
+              if: failure()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TITLE="CI: nightly wasm-bindgen expand check is failing"
+                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  if [ -z "$EXISTING" ]; then
+                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
+                    gh issue create --title "$TITLE" --label ci-failure --assignee madonoharu --body "The scheduled expand check failed.
+
+                  Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
+
+                  This usually means either a new wasm-bindgen release changed the macro output in a way that broke expansion, or a toolchain change altered \`-Zunpretty=expanded\` behavior. See CONTRIBUTING.md for how to regenerate the snapshots."
+                  else
+                    echo "Tracking issue #$EXISTING already open; not filing another."
+                  fi

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -90,7 +90,8 @@ jobs:
                   gh pr create --fill
                   # Assignee/label are decoration; apply after creation so
                   # a failure there cannot block the PR itself.
-                  gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" 2>/dev/null || true
+                  gh label create automated-pr --color EDEDED --description "Created by a scheduled workflow" --force \
+                    || echo "::warning::automated-pr label could not be created or updated"
                   gh pr edit --add-assignee madonoharu --add-label automated-pr \
                     || echo "::warning::PR created but assignee/label could not be applied"
               env:

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -36,42 +36,9 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "24"
-
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-                  components: rustfmt
-
-            - name: Install wasm-pack
-              uses: jetli/wasm-pack-action@v0.4.0
-              with:
-                  # specify exact version to work around
-                  # https://github.com/jetli/wasm-pack-action/issues/23
-                  version: v0.14.0
-
-            - name: Add cargo-expand
-              run: cargo install cargo-expand
-
-            # The expansion snapshots track the *latest* wasm-bindgen release
-            # (Cargo.lock is gitignored, so this resolves fresh every run).
-            # Log the resolved version so failures can be attributed to a
-            # dependency release vs. a toolchain change.
-            - name: Resolve dependencies
-              id: deps
-              run: |
-                  cargo generate-lockfile
-                  WB_VERSION="$(cargo pkgid wasm-bindgen)"
-                  WB_VERSION="${WB_VERSION##*@}"
-                  echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
-                  echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
-                  rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
+            - name: Setup test environment
+              id: setup
+              uses: ./.github/actions/setup-test-env
 
             - name: Setup git config
               run: |
@@ -107,7 +74,7 @@ jobs:
 
                   echo "Creating PR with changes..."
                   git add tests
-                  git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.deps.outputs.wasm_bindgen }}"
+                  git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.setup.outputs.wasm-bindgen-version }}"
                   git push --force --set-upstream origin update-expanded-test-artifacts
 
                   # Check for an existing PR explicitly instead of catching
@@ -129,35 +96,25 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            # Counterpart of "Notify on failure": closing the issue on success
-            # re-arms the alert — one left open would mute every later breakage.
             - name: Close failure tracking issue on success
               if: success()
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
-                  if [ -n "$EXISTING" ]; then
-                    gh issue close "$EXISTING" --comment "Resolved by a successful run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  fi
+              uses: ./.github/actions/track-failure-issue
+              with:
+                  mode: close
+                  title: ${{ env.ISSUE_TITLE }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            # A red run in the Actions tab notifies no one; 75 consecutive
-            # failures went unnoticed in 2026. Open a tracking issue instead
-            # (only once per breakage: skipped while one is already open).
             - name: Notify on failure
               if: failure()
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
-                  if [ -z "$EXISTING" ]; then
-                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
-                    gh issue create --title "$ISSUE_TITLE" --label ci-failure --assignee madonoharu --body "The scheduled expand check failed.
+              uses: ./.github/actions/track-failure-issue
+              with:
+                  mode: notify
+                  title: ${{ env.ISSUE_TITLE }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  body: |
+                      The scheduled expand check failed.
 
-                  Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                  Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
+                      Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                      Resolved wasm-bindgen: ${{ steps.setup.outputs.wasm-bindgen-version || 'unknown' }}
 
-                  Likely causes: a new wasm-bindgen release whose changed macro output breaks expansion, or a toolchain change that altered \`-Zunpretty=expanded\` behavior. See CONTRIBUTING.md for how to regenerate the snapshots."
-                  else
-                    echo "Tracking issue #$EXISTING already open; not filing another."
-                  fi
+                      Likely causes: a new wasm-bindgen release whose changed macro output breaks expansion, or a toolchain change that altered `-Zunpretty=expanded` behavior. See CONTRIBUTING.md for how to regenerate the snapshots.

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -62,7 +62,8 @@ jobs:
               id: deps
               run: |
                   cargo update
-                  WB_VERSION=$(grep -A 1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | cut -d'"' -f2)
+                  WB_VERSION="$(cargo pkgid wasm-bindgen)"
+                  WB_VERSION="${WB_VERSION##*@}"
                   echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
                   echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
                   rustc --version | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -9,8 +9,7 @@ name: Latest deps
 # signal here: a new wasm-bindgen release that changes its codegen makes
 # the snapshots stale by design, and the nightly check-wasmbindgen-changes
 # workflow owns that signal (it regenerates them and opens an update PR).
-# Mixing the two would make this job fail — and notify — on every routine
-# wasm-bindgen release.
+# Mixing the two would fail this job — and notify — on every routine release.
 
 on:
     schedule:
@@ -25,6 +24,12 @@ jobs:
     test-latest:
         name: Test with latest dependencies
         runs-on: ubuntu-latest
+
+        # Single source of truth for the tracking-issue title: "Notify on
+        # failure" and its "Close ... on success" counterpart must search for
+        # the exact same string, or a stale issue would mute all future alerts.
+        env:
+            ISSUE_TITLE: "CI: weekly latest-deps check is failing"
 
         steps:
             - name: Checkout sources
@@ -62,10 +67,9 @@ jobs:
                   echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
                   rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
 
-            # Same commands as ./test.sh, but with the expandtest snapshot
-            # comparison skipped (see the header comment). `--skip expandtest`
-            # filters the test *function* named expandtest inside each test
-            # binary.
+            # Same commands as ./test.sh, minus the expandtest snapshot
+            # comparison (see the header comment). `--skip expandtest` matches
+            # the test *function* name, inside each test binary.
             - name: Run test suite (excluding expand snapshots)
               run: |
                   cargo test --all -- --skip expandtest
@@ -86,30 +90,27 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  TITLE="CI: weekly latest-deps check is failing"
-                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
                   if [ -z "$EXISTING" ]; then
                     gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
-                    gh issue create --title "$TITLE" --label ci-failure --assignee madonoharu --body "The weekly latest-deps run failed.
+                    gh issue create --title "$ISSUE_TITLE" --label ci-failure --assignee madonoharu --body "The weekly latest-deps run failed.
 
                   Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                   Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
 
-                  Compilation or tests are broken against the newest compatible dependency versions — the configuration downstream users actually get. Expansion-snapshot drift is excluded from this job, so it cannot be the cause; this is a real compatibility break."
+                  Compilation or tests are broken against the newest compatible dependency versions — what downstream users actually get. Expansion-snapshot drift is excluded from this job, so it cannot be the cause — this is a real compatibility break."
                   else
                     echo "Tracking issue #$EXISTING already open; not filing another."
                   fi
 
-            # Counterpart of "Notify on failure": once a run succeeds again,
-            # close the tracking issue so the next real breakage can notify
-            # again (an issue that stays open would mute all future alerts).
+            # Counterpart of "Notify on failure": closing the issue on success
+            # re-arms the alert — one left open would mute every later breakage.
             - name: Close failure tracking issue on success
               if: success()
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  TITLE="CI: weekly latest-deps check is failing"
-                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
                   if [ -n "$EXISTING" ]; then
                     gh issue close "$EXISTING" --comment "Resolved by a successful run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   fi

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,12 +1,16 @@
 name: Latest deps
 
-# Compiles and tests the whole workspace against the newest compatible
-# dependency versions, without overwriting any expansion snapshots.
+# Compiles and tests the workspace against the newest compatible dependency
+# versions on a schedule, so a breaking dependency release is noticed even
+# when no PR is being pushed. (PR CI also resolves dependencies fresh, but
+# it only runs when someone opens a PR.)
 #
-# The nightly "Check wasm-bindgen changes" job only exercises the expand
-# snapshots; this job is the only place the full test suite (real
-# compilation, wasm tests, e2e output comparison) runs against the latest
-# dependency resolution — the configuration downstream users actually get.
+# Expansion-snapshot drift is deliberately excluded from the pass/fail
+# signal here: a new wasm-bindgen release that changes its codegen makes
+# the snapshots stale by design, and the nightly check-wasmbindgen-changes
+# workflow owns that signal (it regenerates them and opens an update PR).
+# Mixing the two would make this job fail — and notify — on every routine
+# wasm-bindgen release.
 
 on:
     schedule:
@@ -58,8 +62,24 @@ jobs:
                   echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
                   rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
 
-            - name: Run full test suite
-              run: ./test.sh
+            # Same commands as ./test.sh, but with the expandtest snapshot
+            # comparison skipped (see the header comment). `--skip expandtest`
+            # filters the test *function* named expandtest inside each test
+            # binary.
+            - name: Run test suite (excluding expand snapshots)
+              run: |
+                  cargo test --all -- --skip expandtest
+                  cargo test --all -F js -- --skip expandtest
+                  wasm-pack test --node
+                  wasm-pack test --node -F js
+                  ./tests-e2e/build_all.sh
+                  ./tests-e2e/reference_output/compare_output.sh
+
+            - name: Check expand snapshots (informational only)
+              # Failure here means routine snapshot drift that the nightly
+              # cron will pick up; it must not fail this job.
+              continue-on-error: true
+              run: cargo test -p tsify --test expandtest
 
             - name: Notify on failure
               if: failure()
@@ -75,7 +95,21 @@ jobs:
                   Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                   Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
 
-                  This means tsify no longer builds or passes tests against the newest compatible dependency versions — the configuration downstream users get. If only the expandtest snapshot comparison failed, the nightly cron should shortly open an update PR; otherwise this is a real compatibility break."
+                  Compilation or tests are broken against the newest compatible dependency versions — the configuration downstream users actually get. Expansion-snapshot drift is excluded from this job, so it cannot be the cause; this is a real compatibility break."
                   else
                     echo "Tracking issue #$EXISTING already open; not filing another."
+                  fi
+
+            # Counterpart of "Notify on failure": once a run succeeds again,
+            # close the tracking issue so the next real breakage can notify
+            # again (an issue that stays open would mute all future alerts).
+            - name: Close failure tracking issue on success
+              if: success()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TITLE="CI: weekly latest-deps check is failing"
+                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  if [ -n "$EXISTING" ]; then
+                    gh issue close "$EXISTING" --comment "Resolved by a successful run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   fi

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -35,38 +35,9 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "24"
-
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-                  components: rustfmt
-
-            - name: Install wasm-pack
-              uses: jetli/wasm-pack-action@v0.4.0
-              with:
-                  # specify exact version to work around
-                  # https://github.com/jetli/wasm-pack-action/issues/23
-                  version: v0.14.0
-
-            - name: Add cargo-expand
-              run: cargo install cargo-expand
-
-            - name: Resolve latest dependencies
-              id: deps
-              run: |
-                  cargo update
-                  WB_VERSION="$(cargo pkgid wasm-bindgen)"
-                  WB_VERSION="${WB_VERSION##*@}"
-                  echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
-                  echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
-                  rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
+            - name: Setup test environment
+              id: setup
+              uses: ./.github/actions/setup-test-env
 
             # Same commands as ./test.sh, minus the expandtest snapshot
             # comparison (see the header comment). `--skip expandtest` matches
@@ -86,32 +57,25 @@ jobs:
               continue-on-error: true
               run: cargo test -p tsify --test expandtest
 
-            - name: Notify on failure
-              if: failure()
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
-                  if [ -z "$EXISTING" ]; then
-                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
-                    gh issue create --title "$ISSUE_TITLE" --label ci-failure --assignee madonoharu --body "The weekly latest-deps run failed.
-
-                  Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                  Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
-
-                  Compilation or tests are broken against the newest compatible dependency versions — what downstream users actually get. Expansion-snapshot drift is excluded from this job, so it cannot be the cause — this is a real compatibility break."
-                  else
-                    echo "Tracking issue #$EXISTING already open; not filing another."
-                  fi
-
-            # Counterpart of "Notify on failure": closing the issue on success
-            # re-arms the alert — one left open would mute every later breakage.
             - name: Close failure tracking issue on success
               if: success()
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  EXISTING=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" --json number --jq '.[0].number')
-                  if [ -n "$EXISTING" ]; then
-                    gh issue close "$EXISTING" --comment "Resolved by a successful run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                  fi
+              uses: ./.github/actions/track-failure-issue
+              with:
+                  mode: close
+                  title: ${{ env.ISSUE_TITLE }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Notify on failure
+              if: failure()
+              uses: ./.github/actions/track-failure-issue
+              with:
+                  mode: notify
+                  title: ${{ env.ISSUE_TITLE }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  body: |
+                      The weekly latest-deps run failed.
+
+                      Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                      Resolved wasm-bindgen: ${{ steps.setup.outputs.wasm-bindgen-version || 'unknown' }}
+
+                      Compilation or tests are broken against the newest compatible dependency versions — what downstream users actually get. Expansion-snapshot drift is excluded from this job, so it cannot be the cause — this is a real compatibility break.

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -1,0 +1,81 @@
+name: Latest deps
+
+# Compiles and tests the whole workspace against the newest compatible
+# dependency versions, without overwriting any expansion snapshots.
+#
+# The nightly "Check wasm-bindgen changes" job only exercises the expand
+# snapshots; this job is the only place the full test suite (real
+# compilation, wasm tests, e2e output comparison) runs against the latest
+# dependency resolution — the configuration downstream users actually get.
+
+on:
+    schedule:
+        - cron: "0 2 * * 1" # every Monday 02:00 GMT
+    workflow_dispatch:
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    test-latest:
+        name: Test with latest dependencies
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout sources
+              uses: actions/checkout@v6
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "24"
+
+            - name: Install toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: stable
+                  override: true
+                  components: rustfmt
+
+            - name: Install wasm-pack
+              uses: jetli/wasm-pack-action@v0.4.0
+              with:
+                  # specify exact version to work around
+                  # https://github.com/jetli/wasm-pack-action/issues/23
+                  version: v0.14.0
+
+            - name: Add cargo-expand
+              run: cargo install cargo-expand
+
+            - name: Resolve latest dependencies
+              id: deps
+              run: |
+                  cargo update
+                  WB_VERSION=$(grep -A 1 '^name = "wasm-bindgen"$' Cargo.lock | grep '^version' | head -1 | cut -d'"' -f2)
+                  echo "wasm_bindgen=$WB_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "Resolved wasm-bindgen: $WB_VERSION" | tee -a "$GITHUB_STEP_SUMMARY"
+                  rustc --version | tee -a "$GITHUB_STEP_SUMMARY"
+
+            - name: Run full test suite
+              run: ./test.sh
+
+            - name: Notify on failure
+              if: failure()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TITLE="CI: weekly latest-deps check is failing"
+                  EXISTING=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
+                  if [ -z "$EXISTING" ]; then
+                    gh label create ci-failure --color D93F0B --description "Automated CI failure report" 2>/dev/null || true
+                    gh issue create --title "$TITLE" --label ci-failure --assignee madonoharu --body "The weekly latest-deps run failed.
+
+                  Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  Resolved wasm-bindgen: ${{ steps.deps.outputs.wasm_bindgen || 'unknown' }}
+
+                  This means tsify no longer builds or passes tests against the newest compatible dependency versions — the configuration downstream users get. If only the expandtest snapshot comparison failed, the nightly cron should shortly open an update PR; otherwise this is a real compatibility break."
+                  else
+                    echo "Tracking issue #$EXISTING already open; not filing another."
+                  fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 /target
+# Intentionally not committed: the expansion snapshots in tests/expand/ track
+# the latest wasm-bindgen release, and CI resolves dependencies fresh on every
+# run. See "Why Cargo.lock is not committed" in CONTRIBUTING.md before
+# changing this.
 Cargo.lock
 .vscode
 tests-e2e/*/pkg

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
-# Intentionally not committed: the expansion snapshots in tests/expand/ track
-# the latest wasm-bindgen release, and CI resolves dependencies fresh on every
-# run. See "Why Cargo.lock is not committed" in CONTRIBUTING.md before
+# Intentionally not committed: CI resolves dependencies fresh on every run, so
+# the expansion snapshots in tests/expand/ track the latest wasm-bindgen
+# release. Read "Why Cargo.lock is not committed" in CONTRIBUTING.md before
 # changing this.
 Cargo.lock
 .vscode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,21 +22,18 @@ and Node.js (for the wasm/e2e tests).
 The snapshot files record the full macro expansion of `#[derive(Tsify)]`,
 **including** the code that wasm-bindgen's own macros emit. Because
 `Cargo.lock` is intentionally not committed (see below), CI resolves
-dependencies fresh on every run — so the snapshots always track the **latest
-compatible wasm-bindgen release**, which is the configuration downstream users
-actually get.
+dependencies fresh on every run, so the snapshots always track the **latest
+compatible wasm-bindgen release** — what downstream users actually get.
 
 Two consequences:
 
-1. A new wasm-bindgen release that changes its codegen will make `expandtest`
-   fail with a snapshot diff even though nothing in this repo changed. This is
+1. A new wasm-bindgen release that changes its codegen makes `expandtest` fail
+   with a snapshot diff even though nothing in this repo changed. That is
    expected: the nightly `check-wasmbindgen-changes` workflow regenerates the
-   snapshots and opens an update PR automatically. **Prefer letting the cron
-   do this.** Only regenerate by hand when your own change alters the macro
-   output.
+   snapshots and opens an update PR. **Prefer letting the cron do this** —
+   regenerate by hand only when your own change alters the macro output.
 
-2. When you do regenerate by hand, make sure your local resolution matches
-   CI's before overwriting:
+2. When you regenerate by hand, match CI's resolution before overwriting:
 
    ```sh
    rm -f Cargo.lock && cargo generate-lockfile
@@ -44,16 +41,15 @@ Two consequences:
    ```
 
    Skipping the first line is the classic trap: a stale local `Cargo.lock`
-   (even a few weeks old) can resolve an older wasm-bindgen, producing
+   (even a few weeks old) can resolve an older wasm-bindgen and produce
    snapshots that pass locally but fail in CI. `cargo metadata --locked`
-   will *not* warn about this — the stale version still satisfies the
-   manifest ranges.
+   will *not* warn — the stale version still satisfies the manifest ranges.
 
 ## Why `Cargo.lock` is not committed
 
 Keeping the lockfile out of version control means CI always resolves
-dependencies fresh, so the test suite and the expansion snapshots verify
-tsify against the dependency versions users actually get. The trade-off is
-deliberate: a committed lockfile would make CI reproducible but silently
-stale. If you think this should change, please open an issue rather than
-including the change in an unrelated PR.
+dependencies fresh, so the test suite and the snapshots verify tsify against
+the versions downstream users actually get. The trade-off is deliberate: a
+committed lockfile would make CI reproducible but silently stale. If you
+think that should change, please open an issue rather than bundling it into
+an unrelated PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to tsify
+
+## Running the tests
+
+`./test.sh` runs everything CI runs:
+
+```sh
+cargo test --all
+cargo test --all -F js
+wasm-pack test --node
+wasm-pack test --node -F js
+./tests-e2e/build_all.sh
+./tests-e2e/reference_output/compare_output.sh
+```
+
+Required tools: stable Rust, [wasm-pack](https://rustwasm.github.io/wasm-pack/),
+[cargo-expand](https://github.com/dtolnay/cargo-expand) (for the expand tests),
+and Node.js (for the wasm/e2e tests).
+
+## Expansion snapshots (`tests/expand/*.expanded.rs`)
+
+The snapshot files record the full macro expansion of `#[derive(Tsify)]`,
+**including** the code that wasm-bindgen's own macros emit. Because
+`Cargo.lock` is intentionally not committed (see below), CI resolves
+dependencies fresh on every run — so the snapshots always track the **latest
+compatible wasm-bindgen release**, which is the configuration downstream users
+actually get.
+
+Two consequences:
+
+1. A new wasm-bindgen release that changes its codegen will make `expandtest`
+   fail with a snapshot diff even though nothing in this repo changed. This is
+   expected: the nightly `check-wasmbindgen-changes` workflow regenerates the
+   snapshots and opens an update PR automatically. **Prefer letting the cron
+   do this.** Only regenerate by hand when your own change alters the macro
+   output.
+
+2. When you do regenerate by hand, make sure your local resolution matches
+   CI's before overwriting:
+
+   ```sh
+   rm -f Cargo.lock && cargo generate-lockfile
+   MACROTEST=overwrite cargo test -p tsify --test expandtest
+   ```
+
+   Skipping the first line is the classic trap: a stale local `Cargo.lock`
+   (even a few weeks old) can resolve an older wasm-bindgen, producing
+   snapshots that pass locally but fail in CI. `cargo metadata --locked`
+   will *not* warn about this — the stale version still satisfies the
+   manifest ranges.
+
+## Why `Cargo.lock` is not committed
+
+This is a deliberate decision, revisited in 2026 (not a leftover default):
+the expansion snapshots and the full test suite are meant to verify tsify
+against the dependency versions users actually resolve, not against a pinned
+set. The trade-offs and the conditions under which this may change are
+tracked by the maintainers. If you think a lockfile should be committed,
+please open an issue rather than including the change in an unrelated PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,9 @@ Two consequences:
 
 ## Why `Cargo.lock` is not committed
 
-This is a deliberate decision, revisited in 2026 (not a leftover default):
-the expansion snapshots and the full test suite are meant to verify tsify
-against the dependency versions users actually resolve, not against a pinned
-set. The trade-offs and the conditions under which this may change are
-tracked by the maintainers. If you think a lockfile should be committed,
-please open an issue rather than including the change in an unrelated PR.
+Keeping the lockfile out of version control means CI always resolves
+dependencies fresh, so the test suite and the expansion snapshots verify
+tsify against the dependency versions users actually get. The trade-off is
+deliberate: a committed lockfile would make CI reproducible but silently
+stale. If you think this should change, please open an issue rather than
+including the change in an unrelated PR.

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -15,11 +15,211 @@ const _: () = {
         },
         describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
     };
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(typescript_type = "Borrow")]
-        pub type JsType;
+    #[repr(transparent)]
+    pub struct JsType {
+        obj: wasm_bindgen::JsValue,
     }
+    #[automatically_derived]
+    impl ::core::clone::Clone for JsType {
+        #[inline]
+        fn clone(&self) -> JsType {
+            JsType {
+                obj: ::core::clone::Clone::clone(&self.obj),
+            }
+        }
+    }
+    #[automatically_derived]
+    const _: () = {
+        use wasm_bindgen::convert::TryFromJsValue;
+        use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+        use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
+        use wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
+        use wasm_bindgen::describe::WasmDescribe;
+        use wasm_bindgen::{JsValue, JsCast};
+        use wasm_bindgen::__rt::{core, marker::ErasableGeneric};
+        #[automatically_derived]
+        impl WasmDescribe for JsType {
+            fn describe() {
+                use wasm_bindgen::describe::*;
+                inform(NAMED_EXTERNREF);
+                inform(6u32);
+                inform(66u32);
+                inform(111u32);
+                inform(114u32);
+                inform(114u32);
+                inform(111u32);
+                inform(119u32);
+            }
+        }
+        #[automatically_derived]
+        impl IntoWasmAbi for JsType {
+            type Abi = <JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                self.obj.into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl OptionIntoWasmAbi for JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> OptionIntoWasmAbi for &'a JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl FromWasmAbi for JsType {
+            type Abi = <JsValue as FromWasmAbi>::Abi;
+            #[inline]
+            unsafe fn from_abi(js: Self::Abi) -> Self {
+                JsType {
+                    obj: JsValue::from_abi(js).into(),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl OptionFromWasmAbi for JsType {
+            #[inline]
+            fn is_none(abi: &Self::Abi) -> bool {
+                *abi == 0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> IntoWasmAbi for &'a JsType {
+            type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                (&self.obj).into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl RefFromWasmAbi for JsType {
+            type Abi = <JsValue as RefFromWasmAbi>::Abi;
+            type Anchor = wasm_bindgen::__rt::core::mem::ManuallyDrop<JsType>;
+            #[inline]
+            unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as RefFromWasmAbi>::ref_from_abi(js);
+                wasm_bindgen::__rt::core::mem::ManuallyDrop::new(JsType {
+                    obj: wasm_bindgen::__rt::core::mem::ManuallyDrop::into_inner(tmp)
+                        .into(),
+                })
+            }
+        }
+        #[automatically_derived]
+        impl LongRefFromWasmAbi for JsType {
+            type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
+            type Anchor = JsType;
+            #[inline]
+            unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as LongRefFromWasmAbi>::long_ref_from_abi(js);
+                JsType { obj: tmp.into() }
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsValue> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsValue {
+                self.obj.as_ref()
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsType> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsType {
+                self
+            }
+        }
+        #[automatically_derived]
+        impl wasm_bindgen::IntoJsGeneric for JsType
+        where
+            JsType: wasm_bindgen::JsGeneric,
+        {
+            type JsCanon = JsType;
+            #[inline]
+            fn to_js(self) -> JsType {
+                unsafe {
+                    wasm_bindgen::__rt::core::mem::transmute_copy(
+                        &wasm_bindgen::__rt::core::mem::ManuallyDrop::new(self),
+                    )
+                }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsValue> for JsType {
+            #[inline]
+            fn from(obj: JsValue) -> Self {
+                JsType { obj: obj.into() }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsType> for JsValue {
+            #[inline]
+            fn from(obj: JsType) -> JsValue {
+                obj.obj.into()
+            }
+        }
+        #[automatically_derived]
+        impl JsCast for JsType {
+            fn instanceof(val: &JsValue) -> bool {
+                unsafe fn __wbg_instanceof_JsType_07a4c56f90e9a47b(_: u32) -> u32 {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("cannot check instanceof on non-wasm targets"),
+                        );
+                    };
+                }
+                unsafe {
+                    let idx = val.into_abi();
+                    __wbg_instanceof_JsType_07a4c56f90e9a47b(idx) != 0
+                }
+            }
+            #[inline]
+            fn unchecked_from_js(val: JsValue) -> Self {
+                JsType { obj: val.into() }
+            }
+            #[inline]
+            fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+                unsafe { &*(val as *const JsValue as *const Self) }
+            }
+        }
+        unsafe impl ErasableGeneric for JsType {
+            type Repr = JsValue;
+        }
+    };
+    #[automatically_derived]
+    impl wasm_bindgen::sys::Promising for JsType {
+        type Resolution = JsType;
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::__rt::core::ops::Deref for JsType {
+        type Target = wasm_bindgen::JsValue;
+        #[inline]
+        fn deref(&self) -> &wasm_bindgen::JsValue {
+            &self.obj
+        }
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for wasm_bindgen::JsValue {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for JsType {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<JsType> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<JsType> {}
     #[automatically_derived]
     impl<'a> Tsify for Borrow<'a> {
         type JsType = JsType;
@@ -30,8 +230,6 @@ const _: () = {
             large_number_types_as_bigints: false,
         };
     }
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export interface Borrow {\n    raw: string;\n    cow: string;\n}";
     #[automatically_derived]
     impl<'a> WasmDescribe for Borrow<'a> {
         #[inline]

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -16,11 +16,216 @@ const _: () = {
         },
         describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
     };
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(typescript_type = "GenericEnum")]
-        pub type JsType;
+    #[repr(transparent)]
+    pub struct JsType {
+        obj: wasm_bindgen::JsValue,
     }
+    #[automatically_derived]
+    impl ::core::clone::Clone for JsType {
+        #[inline]
+        fn clone(&self) -> JsType {
+            JsType {
+                obj: ::core::clone::Clone::clone(&self.obj),
+            }
+        }
+    }
+    #[automatically_derived]
+    const _: () = {
+        use wasm_bindgen::convert::TryFromJsValue;
+        use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+        use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
+        use wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
+        use wasm_bindgen::describe::WasmDescribe;
+        use wasm_bindgen::{JsValue, JsCast};
+        use wasm_bindgen::__rt::{core, marker::ErasableGeneric};
+        #[automatically_derived]
+        impl WasmDescribe for JsType {
+            fn describe() {
+                use wasm_bindgen::describe::*;
+                inform(NAMED_EXTERNREF);
+                inform(11u32);
+                inform(71u32);
+                inform(101u32);
+                inform(110u32);
+                inform(101u32);
+                inform(114u32);
+                inform(105u32);
+                inform(99u32);
+                inform(69u32);
+                inform(110u32);
+                inform(117u32);
+                inform(109u32);
+            }
+        }
+        #[automatically_derived]
+        impl IntoWasmAbi for JsType {
+            type Abi = <JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                self.obj.into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl OptionIntoWasmAbi for JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> OptionIntoWasmAbi for &'a JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl FromWasmAbi for JsType {
+            type Abi = <JsValue as FromWasmAbi>::Abi;
+            #[inline]
+            unsafe fn from_abi(js: Self::Abi) -> Self {
+                JsType {
+                    obj: JsValue::from_abi(js).into(),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl OptionFromWasmAbi for JsType {
+            #[inline]
+            fn is_none(abi: &Self::Abi) -> bool {
+                *abi == 0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> IntoWasmAbi for &'a JsType {
+            type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                (&self.obj).into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl RefFromWasmAbi for JsType {
+            type Abi = <JsValue as RefFromWasmAbi>::Abi;
+            type Anchor = wasm_bindgen::__rt::core::mem::ManuallyDrop<JsType>;
+            #[inline]
+            unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as RefFromWasmAbi>::ref_from_abi(js);
+                wasm_bindgen::__rt::core::mem::ManuallyDrop::new(JsType {
+                    obj: wasm_bindgen::__rt::core::mem::ManuallyDrop::into_inner(tmp)
+                        .into(),
+                })
+            }
+        }
+        #[automatically_derived]
+        impl LongRefFromWasmAbi for JsType {
+            type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
+            type Anchor = JsType;
+            #[inline]
+            unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as LongRefFromWasmAbi>::long_ref_from_abi(js);
+                JsType { obj: tmp.into() }
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsValue> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsValue {
+                self.obj.as_ref()
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsType> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsType {
+                self
+            }
+        }
+        #[automatically_derived]
+        impl wasm_bindgen::IntoJsGeneric for JsType
+        where
+            JsType: wasm_bindgen::JsGeneric,
+        {
+            type JsCanon = JsType;
+            #[inline]
+            fn to_js(self) -> JsType {
+                unsafe {
+                    wasm_bindgen::__rt::core::mem::transmute_copy(
+                        &wasm_bindgen::__rt::core::mem::ManuallyDrop::new(self),
+                    )
+                }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsValue> for JsType {
+            #[inline]
+            fn from(obj: JsValue) -> Self {
+                JsType { obj: obj.into() }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsType> for JsValue {
+            #[inline]
+            fn from(obj: JsType) -> JsValue {
+                obj.obj.into()
+            }
+        }
+        #[automatically_derived]
+        impl JsCast for JsType {
+            fn instanceof(val: &JsValue) -> bool {
+                unsafe fn __wbg_instanceof_JsType_07a4c56f90e9a47b(_: u32) -> u32 {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("cannot check instanceof on non-wasm targets"),
+                        );
+                    };
+                }
+                unsafe {
+                    let idx = val.into_abi();
+                    __wbg_instanceof_JsType_07a4c56f90e9a47b(idx) != 0
+                }
+            }
+            #[inline]
+            fn unchecked_from_js(val: JsValue) -> Self {
+                JsType { obj: val.into() }
+            }
+            #[inline]
+            fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+                unsafe { &*(val as *const JsValue as *const Self) }
+            }
+        }
+        unsafe impl ErasableGeneric for JsType {
+            type Repr = JsValue;
+        }
+    };
+    #[automatically_derived]
+    impl wasm_bindgen::sys::Promising for JsType {
+        type Resolution = JsType;
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::__rt::core::ops::Deref for JsType {
+        type Target = wasm_bindgen::JsValue;
+        #[inline]
+        fn deref(&self) -> &wasm_bindgen::JsValue {
+            &self.obj
+        }
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for wasm_bindgen::JsValue {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for JsType {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<JsType> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<JsType> {}
     #[automatically_derived]
     impl<T, U> Tsify for GenericEnum<T, U> {
         type JsType = JsType;
@@ -31,8 +236,6 @@ const _: () = {
             large_number_types_as_bigints: false,
         };
     }
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export type GenericEnum<T, U> = \"Unit\" | { NewType: T } | { Seq: [T, U] } | { Map: { x: T; y: U } };";
     #[automatically_derived]
     impl<T, U> WasmDescribe for GenericEnum<T, U> {
         #[inline]

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -13,11 +13,218 @@ const _: () = {
         },
         describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
     };
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(typescript_type = "GenericStruct")]
-        pub type JsType;
+    #[repr(transparent)]
+    pub struct JsType {
+        obj: wasm_bindgen::JsValue,
     }
+    #[automatically_derived]
+    impl ::core::clone::Clone for JsType {
+        #[inline]
+        fn clone(&self) -> JsType {
+            JsType {
+                obj: ::core::clone::Clone::clone(&self.obj),
+            }
+        }
+    }
+    #[automatically_derived]
+    const _: () = {
+        use wasm_bindgen::convert::TryFromJsValue;
+        use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+        use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
+        use wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
+        use wasm_bindgen::describe::WasmDescribe;
+        use wasm_bindgen::{JsValue, JsCast};
+        use wasm_bindgen::__rt::{core, marker::ErasableGeneric};
+        #[automatically_derived]
+        impl WasmDescribe for JsType {
+            fn describe() {
+                use wasm_bindgen::describe::*;
+                inform(NAMED_EXTERNREF);
+                inform(13u32);
+                inform(71u32);
+                inform(101u32);
+                inform(110u32);
+                inform(101u32);
+                inform(114u32);
+                inform(105u32);
+                inform(99u32);
+                inform(83u32);
+                inform(116u32);
+                inform(114u32);
+                inform(117u32);
+                inform(99u32);
+                inform(116u32);
+            }
+        }
+        #[automatically_derived]
+        impl IntoWasmAbi for JsType {
+            type Abi = <JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                self.obj.into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl OptionIntoWasmAbi for JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> OptionIntoWasmAbi for &'a JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl FromWasmAbi for JsType {
+            type Abi = <JsValue as FromWasmAbi>::Abi;
+            #[inline]
+            unsafe fn from_abi(js: Self::Abi) -> Self {
+                JsType {
+                    obj: JsValue::from_abi(js).into(),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl OptionFromWasmAbi for JsType {
+            #[inline]
+            fn is_none(abi: &Self::Abi) -> bool {
+                *abi == 0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> IntoWasmAbi for &'a JsType {
+            type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                (&self.obj).into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl RefFromWasmAbi for JsType {
+            type Abi = <JsValue as RefFromWasmAbi>::Abi;
+            type Anchor = wasm_bindgen::__rt::core::mem::ManuallyDrop<JsType>;
+            #[inline]
+            unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as RefFromWasmAbi>::ref_from_abi(js);
+                wasm_bindgen::__rt::core::mem::ManuallyDrop::new(JsType {
+                    obj: wasm_bindgen::__rt::core::mem::ManuallyDrop::into_inner(tmp)
+                        .into(),
+                })
+            }
+        }
+        #[automatically_derived]
+        impl LongRefFromWasmAbi for JsType {
+            type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
+            type Anchor = JsType;
+            #[inline]
+            unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as LongRefFromWasmAbi>::long_ref_from_abi(js);
+                JsType { obj: tmp.into() }
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsValue> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsValue {
+                self.obj.as_ref()
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsType> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsType {
+                self
+            }
+        }
+        #[automatically_derived]
+        impl wasm_bindgen::IntoJsGeneric for JsType
+        where
+            JsType: wasm_bindgen::JsGeneric,
+        {
+            type JsCanon = JsType;
+            #[inline]
+            fn to_js(self) -> JsType {
+                unsafe {
+                    wasm_bindgen::__rt::core::mem::transmute_copy(
+                        &wasm_bindgen::__rt::core::mem::ManuallyDrop::new(self),
+                    )
+                }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsValue> for JsType {
+            #[inline]
+            fn from(obj: JsValue) -> Self {
+                JsType { obj: obj.into() }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsType> for JsValue {
+            #[inline]
+            fn from(obj: JsType) -> JsValue {
+                obj.obj.into()
+            }
+        }
+        #[automatically_derived]
+        impl JsCast for JsType {
+            fn instanceof(val: &JsValue) -> bool {
+                unsafe fn __wbg_instanceof_JsType_07a4c56f90e9a47b(_: u32) -> u32 {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("cannot check instanceof on non-wasm targets"),
+                        );
+                    };
+                }
+                unsafe {
+                    let idx = val.into_abi();
+                    __wbg_instanceof_JsType_07a4c56f90e9a47b(idx) != 0
+                }
+            }
+            #[inline]
+            fn unchecked_from_js(val: JsValue) -> Self {
+                JsType { obj: val.into() }
+            }
+            #[inline]
+            fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+                unsafe { &*(val as *const JsValue as *const Self) }
+            }
+        }
+        unsafe impl ErasableGeneric for JsType {
+            type Repr = JsValue;
+        }
+    };
+    #[automatically_derived]
+    impl wasm_bindgen::sys::Promising for JsType {
+        type Resolution = JsType;
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::__rt::core::ops::Deref for JsType {
+        type Target = wasm_bindgen::JsValue;
+        #[inline]
+        fn deref(&self) -> &wasm_bindgen::JsValue {
+            &self.obj
+        }
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for wasm_bindgen::JsValue {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for JsType {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<JsType> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<JsType> {}
     #[automatically_derived]
     impl<T> Tsify for GenericStruct<T> {
         type JsType = JsType;
@@ -28,8 +235,6 @@ const _: () = {
             large_number_types_as_bigints: false,
         };
     }
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export interface GenericStruct<T> {\n    x: T;\n}";
     #[automatically_derived]
     impl<T> WasmDescribe for GenericStruct<T> {
         #[inline]
@@ -238,11 +443,219 @@ const _: () = {
         },
         describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
     };
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(typescript_type = "GenericNewtype")]
-        pub type JsType;
+    #[repr(transparent)]
+    pub struct JsType {
+        obj: wasm_bindgen::JsValue,
     }
+    #[automatically_derived]
+    impl ::core::clone::Clone for JsType {
+        #[inline]
+        fn clone(&self) -> JsType {
+            JsType {
+                obj: ::core::clone::Clone::clone(&self.obj),
+            }
+        }
+    }
+    #[automatically_derived]
+    const _: () = {
+        use wasm_bindgen::convert::TryFromJsValue;
+        use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+        use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
+        use wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
+        use wasm_bindgen::describe::WasmDescribe;
+        use wasm_bindgen::{JsValue, JsCast};
+        use wasm_bindgen::__rt::{core, marker::ErasableGeneric};
+        #[automatically_derived]
+        impl WasmDescribe for JsType {
+            fn describe() {
+                use wasm_bindgen::describe::*;
+                inform(NAMED_EXTERNREF);
+                inform(14u32);
+                inform(71u32);
+                inform(101u32);
+                inform(110u32);
+                inform(101u32);
+                inform(114u32);
+                inform(105u32);
+                inform(99u32);
+                inform(78u32);
+                inform(101u32);
+                inform(119u32);
+                inform(116u32);
+                inform(121u32);
+                inform(112u32);
+                inform(101u32);
+            }
+        }
+        #[automatically_derived]
+        impl IntoWasmAbi for JsType {
+            type Abi = <JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                self.obj.into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl OptionIntoWasmAbi for JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> OptionIntoWasmAbi for &'a JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl FromWasmAbi for JsType {
+            type Abi = <JsValue as FromWasmAbi>::Abi;
+            #[inline]
+            unsafe fn from_abi(js: Self::Abi) -> Self {
+                JsType {
+                    obj: JsValue::from_abi(js).into(),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl OptionFromWasmAbi for JsType {
+            #[inline]
+            fn is_none(abi: &Self::Abi) -> bool {
+                *abi == 0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> IntoWasmAbi for &'a JsType {
+            type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                (&self.obj).into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl RefFromWasmAbi for JsType {
+            type Abi = <JsValue as RefFromWasmAbi>::Abi;
+            type Anchor = wasm_bindgen::__rt::core::mem::ManuallyDrop<JsType>;
+            #[inline]
+            unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as RefFromWasmAbi>::ref_from_abi(js);
+                wasm_bindgen::__rt::core::mem::ManuallyDrop::new(JsType {
+                    obj: wasm_bindgen::__rt::core::mem::ManuallyDrop::into_inner(tmp)
+                        .into(),
+                })
+            }
+        }
+        #[automatically_derived]
+        impl LongRefFromWasmAbi for JsType {
+            type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
+            type Anchor = JsType;
+            #[inline]
+            unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as LongRefFromWasmAbi>::long_ref_from_abi(js);
+                JsType { obj: tmp.into() }
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsValue> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsValue {
+                self.obj.as_ref()
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsType> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsType {
+                self
+            }
+        }
+        #[automatically_derived]
+        impl wasm_bindgen::IntoJsGeneric for JsType
+        where
+            JsType: wasm_bindgen::JsGeneric,
+        {
+            type JsCanon = JsType;
+            #[inline]
+            fn to_js(self) -> JsType {
+                unsafe {
+                    wasm_bindgen::__rt::core::mem::transmute_copy(
+                        &wasm_bindgen::__rt::core::mem::ManuallyDrop::new(self),
+                    )
+                }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsValue> for JsType {
+            #[inline]
+            fn from(obj: JsValue) -> Self {
+                JsType { obj: obj.into() }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsType> for JsValue {
+            #[inline]
+            fn from(obj: JsType) -> JsValue {
+                obj.obj.into()
+            }
+        }
+        #[automatically_derived]
+        impl JsCast for JsType {
+            fn instanceof(val: &JsValue) -> bool {
+                unsafe fn __wbg_instanceof_JsType_07a4c56f90e9a47b(_: u32) -> u32 {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("cannot check instanceof on non-wasm targets"),
+                        );
+                    };
+                }
+                unsafe {
+                    let idx = val.into_abi();
+                    __wbg_instanceof_JsType_07a4c56f90e9a47b(idx) != 0
+                }
+            }
+            #[inline]
+            fn unchecked_from_js(val: JsValue) -> Self {
+                JsType { obj: val.into() }
+            }
+            #[inline]
+            fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+                unsafe { &*(val as *const JsValue as *const Self) }
+            }
+        }
+        unsafe impl ErasableGeneric for JsType {
+            type Repr = JsValue;
+        }
+    };
+    #[automatically_derived]
+    impl wasm_bindgen::sys::Promising for JsType {
+        type Resolution = JsType;
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::__rt::core::ops::Deref for JsType {
+        type Target = wasm_bindgen::JsValue;
+        #[inline]
+        fn deref(&self) -> &wasm_bindgen::JsValue {
+            &self.obj
+        }
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for wasm_bindgen::JsValue {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for JsType {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<JsType> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<JsType> {}
     #[automatically_derived]
     impl<T> Tsify for GenericNewtype<T> {
         type JsType = JsType;
@@ -253,8 +666,6 @@ const _: () = {
             large_number_types_as_bigints: false,
         };
     }
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export type GenericNewtype<T> = T;";
     #[automatically_derived]
     impl<T> WasmDescribe for GenericNewtype<T> {
         #[inline]

--- a/tests/expand/type_alias.expanded.rs
+++ b/tests/expand/type_alias.expanded.rs
@@ -1,6 +1,4 @@
 type TypeAlias<T, U> = Foo<T, i32, U>;
 const _: () = {
     use wasm_bindgen::prelude::*;
-    #[wasm_bindgen(typescript_custom_section)]
-    const TS_APPEND_CONTENT: &'static str = "export type TypeAlias<T, U> = Foo<T, number, U>;";
 };

--- a/tests/expandtest.rs
+++ b/tests/expandtest.rs
@@ -1,11 +1,12 @@
 //! Generates expanded code for tests in `tests/expand/` directory.
 //! To update the expected output, run with `MACROTEST=overwrite cargo test`
 //! or delete the `*.expanded.rs` files.
+//!
+//! `--features json,wasm-bindgen` enables the *test project's* own features,
+//! not just tsify's, so the optional `serde` and `wasm-bindgen` dependencies
+//! are resolvable from the code `#[derive(Tsify)]` emits.
 
 #[test]
 fn expandtest() {
-    // Enable the test project's own `json` and `wasm-bindgen` features (not
-    // just tsify's) so the `serde` and `wasm-bindgen` optional dependencies
-    // are resolvable from the code emitted by `#[derive(Tsify)]`.
     macrotest::expand_args("tests/expand/*.rs", ["--features", "json,wasm-bindgen"]);
 }

--- a/tests/expandtest.rs
+++ b/tests/expandtest.rs
@@ -4,5 +4,8 @@
 
 #[test]
 fn expandtest() {
-    macrotest::expand_args("tests/expand/*.rs", ["--features", "tsify/json"]);
+    // Enable the test project's own `json` and `wasm-bindgen` features (not
+    // just tsify's) so the `serde` and `wasm-bindgen` optional dependencies
+    // are resolvable from the code emitted by `#[derive(Tsify)]`.
+    macrotest::expand_args("tests/expand/*.rs", ["--features", "json,wasm-bindgen"]);
 }

--- a/tsify-macros/src/type_alias.rs
+++ b/tsify-macros/src/type_alias.rs
@@ -43,3 +43,7 @@ pub fn expand(item: syn::ItemType) -> syn::Result<TokenStream> {
 
     Ok(tokens)
 }
+
+#[cfg(test)]
+#[path = "type_alias.test.rs"]
+mod test;

--- a/tsify-macros/src/type_alias.test.rs
+++ b/tsify-macros/src/type_alias.test.rs
@@ -2,8 +2,19 @@ use super::expand;
 
 // `#[tsify::declare]` emits its TypeScript declaration only through
 // `#[wasm_bindgen(typescript_custom_section)]`, which expands to nothing on
-// non-wasm targets — so the expansion snapshots in tests/expand/ cannot see
-// the declaration text. These tests assert on it directly.
+// non-wasm targets — so the snapshots in tests/expand/ never contain the
+// declaration text. These tests assert on it directly.
+
+macro_rules! assert_contains {
+    ($tokens:expr, $( $needle:expr ),+ $(,)?) => {
+        $(assert!(
+            $tokens.contains($needle),
+            "expected {:?} in expansion, got: {}",
+            $needle,
+            $tokens
+        );)+
+    };
+}
 
 fn expand_to_string(item: syn::ItemType) -> String {
     expand(item).unwrap().to_string()
@@ -14,12 +25,12 @@ fn test_declare_emits_exported_type_alias() {
     let tokens = expand_to_string(syn::parse_quote! {
         type TypeAlias<T, U> = Foo<T, i32, U>;
     });
-    assert!(
-        tokens.contains("export type TypeAlias<T, U> = Foo<T, number, U>;"),
-        "expected TS alias declaration in expansion, got: {tokens}"
+    assert_contains!(
+        tokens,
+        "export type TypeAlias<T, U> = Foo<T, number, U>;",
+        "TS_APPEND_CONTENT",
+        "typescript_custom_section",
     );
-    assert!(tokens.contains("TS_APPEND_CONTENT"));
-    assert!(tokens.contains("typescript_custom_section"));
 }
 
 #[test]
@@ -27,10 +38,7 @@ fn test_declare_without_generics() {
     let tokens = expand_to_string(syn::parse_quote! {
         type Simple = Vec<String>;
     });
-    assert!(
-        tokens.contains("export type Simple = string[];"),
-        "expected TS alias declaration in expansion, got: {tokens}"
-    );
+    assert_contains!(tokens, "export type Simple = string[];");
 }
 
 #[test]
@@ -39,9 +47,5 @@ fn test_declare_keeps_doc_comments() {
         /// Alias docs
         type Documented = i32;
     });
-    assert!(
-        tokens.contains("Alias docs"),
-        "expected doc comment to be carried into the TS declaration, got: {tokens}"
-    );
-    assert!(tokens.contains("export type Documented = number;"));
+    assert_contains!(tokens, "Alias docs", "export type Documented = number;");
 }

--- a/tsify-macros/src/type_alias.test.rs
+++ b/tsify-macros/src/type_alias.test.rs
@@ -1,0 +1,47 @@
+use super::expand;
+
+// `#[tsify::declare]` emits its TypeScript declaration only through
+// `#[wasm_bindgen(typescript_custom_section)]`, which expands to nothing on
+// non-wasm targets — so the expansion snapshots in tests/expand/ cannot see
+// the declaration text. These tests assert on it directly.
+
+fn expand_to_string(item: syn::ItemType) -> String {
+    expand(item).unwrap().to_string()
+}
+
+#[test]
+fn test_declare_emits_exported_type_alias() {
+    let tokens = expand_to_string(syn::parse_quote! {
+        type TypeAlias<T, U> = Foo<T, i32, U>;
+    });
+    assert!(
+        tokens.contains("export type TypeAlias<T, U> = Foo<T, number, U>;"),
+        "expected TS alias declaration in expansion, got: {tokens}"
+    );
+    assert!(tokens.contains("TS_APPEND_CONTENT"));
+    assert!(tokens.contains("typescript_custom_section"));
+}
+
+#[test]
+fn test_declare_without_generics() {
+    let tokens = expand_to_string(syn::parse_quote! {
+        type Simple = Vec<String>;
+    });
+    assert!(
+        tokens.contains("export type Simple = string[];"),
+        "expected TS alias declaration in expansion, got: {tokens}"
+    );
+}
+
+#[test]
+fn test_declare_keeps_doc_comments() {
+    let tokens = expand_to_string(syn::parse_quote! {
+        /// Alias docs
+        type Documented = i32;
+    });
+    assert!(
+        tokens.contains("Alias docs"),
+        "expected doc comment to be carried into the TS declaration, got: {tokens}"
+    );
+    assert!(tokens.contains("export type Documented = number;"));
+}


### PR DESCRIPTION
Fixes the expand tests (3 of 4 failing in CI since June) and hardens the scheduled workflows so this class of breakage can't go unnoticed again.

## Root cause

macrotest translates tsify's `[features]` table into its temporary test project but drops feature references that don't start with `dep:`. `--features tsify/json` therefore never enabled the temp project's own `serde` / `wasm-bindgen` optional deps, so the code emitted by `#[derive(Tsify)]` couldn't resolve those crates (E0463/E0433). Older rustc tolerated unresolved macros during expansion and printed partially-expanded output — that's what the old snapshots recorded. Current rustc makes this a hard error. Nothing in this repo changed; the toolchain did.

## Changes

- **expandtest**: pass `--features json,wasm-bindgen` (the test project's own features) and regenerate the snapshots. They are now fully expanded, which also restores the diff sensitivity the nightly cron relies on — the old partially-expanded snapshots never changed across 13 wasm-bindgen releases, which is why the cron never opened an update PR.
- **Snapshots track the latest wasm-bindgen** (`Cargo.lock` is gitignored; CI resolves fresh), currently 0.2.127. Future codegen changes will be picked up by the cron as designed.
- **`#[tsify::declare]` unit tests**: with full expansion, `type_alias.expanded.rs` no longer captures the emitted TS declaration (`typescript_custom_section` expands to nothing on non-wasm targets), so tsify-macros now asserts it directly.
- **`check-wasmbindgen-changes.yml`**: explicit token permissions, resolved wasm-bindgen version in the logs and PR title, a tracking issue on failure (exact-title deduped, auto-closed on recovery), assignee/label on auto-PRs, and PR-creation failures now propagate instead of being swallowed.
- **`latest-deps.yml`** (new): weekly full test run against fresh dependency resolution, with the snapshot comparison excluded from pass/fail — routine codegen drift belongs to the nightly cron.
- **Shared composite actions** (new, `.github/actions/`): both scheduled workflows use the same environment setup and tracking-issue plumbing. Setup now calls `rustup` directly instead of the archived `actions-rs/toolchain`.
- **`CONTRIBUTING.md`** (new): test setup, snapshot regeneration (fresh lockfile first), and the lockfile policy.

## Note

The cron's PR-creation path has never fired in production; worth a manual `workflow_dispatch` run after this merges to prove it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
