### PR TITLE
Harden the scheduled workflows

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -31,9 +31,12 @@ runs:
               # https://github.com/jetli/wasm-pack-action/issues/23
               version: v0.14.0
 
+        # Pinned: cargo-expand's own output shape feeds the snapshots, so an
+        # unpinned upgrade would show up as codegen drift and misattribute it
+        # to a dependency release.
         - name: Add cargo-expand
           shell: bash
-          run: cargo install cargo-expand
+          run: cargo install cargo-expand --version 1.0.124 --locked
 
         # Log the resolved wasm-bindgen version so failures can be attributed
         # to a dependency release vs. a toolchain change.

--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -31,9 +31,8 @@ runs:
               # https://github.com/jetli/wasm-pack-action/issues/23
               version: v0.14.0
 
-        # Pinned: cargo-expand's own output shape feeds the snapshots, so an
-        # unpinned upgrade would show up as codegen drift and misattribute it
-        # to a dependency release.
+        # cargo-expand's output shape feeds the snapshots, so an unpinned
+        # upgrade would read as codegen drift and misattribute the cause.
         - name: Add cargo-expand
           shell: bash
           run: cargo install cargo-expand --version 1.0.124 --locked

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -13,6 +13,12 @@ on:
         - cron: "0 0 * * *" # every day at midnight GMT
     workflow_dispatch:
 
+# The bot branch is force-pushed, so a manual run overlapping the nightly one
+# would have them overwrite each other's work.
+concurrency:
+    group: check-wasmbindgen-changes
+    cancel-in-progress: false
+
 env:
     TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
 
@@ -67,13 +73,15 @@ jobs:
 
             - name: Check for changes
               run: |
-                  if git diff --quiet -- tests; then
+                  # `git diff` alone would miss a snapshot for a newly added
+                  # test, which is untracked until it is staged.
+                  git add -A tests
+                  if git diff --cached --quiet -- tests; then
                     echo "Expanded test artifacts are unchanged; nothing to do."
                     exit 0
                   fi
 
                   echo "Creating PR with changes..."
-                  git add tests
                   git commit -m "Update expanded test artifacts for wasm-bindgen ${{ steps.setup.outputs.wasm-bindgen-version }}"
                   git push --force --set-upstream origin update-expanded-test-artifacts
 

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -16,6 +16,12 @@ on:
         - cron: "0 2 * * 1" # every Monday 02:00 GMT
     workflow_dispatch:
 
+# Two runs racing would each decide independently whether to file or close the
+# tracking issue.
+concurrency:
+    group: latest-deps
+    cancel-in-progress: false
+
 permissions:
     contents: read
     issues: write
@@ -34,6 +40,10 @@ jobs:
         steps:
             - name: Checkout sources
               uses: actions/checkout@v6
+              with:
+                  # This job only builds and tests; it never pushes, so the
+                  # checkout token should not stay available to the build.
+                  persist-credentials: false
 
             - name: Setup test environment
               id: setup

--- a/.github/workflows/latest-deps.yml
+++ b/.github/workflows/latest-deps.yml
@@ -41,8 +41,7 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
               with:
-                  # This job only builds and tests; it never pushes, so the
-                  # checkout token should not stay available to the build.
+                  # Nothing here pushes, so don't leave the token to the build.
                   persist-credentials: false
 
             - name: Setup test environment

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,21 +16,13 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
+              run: rustup toolchain install stable --profile minimal --override
 
             - name: Check
-              uses: actions-rs/cargo@v1
-              with:
-                  command: check
+              run: cargo check
 
             - name: Build
-              uses: actions-rs/cargo@v1
-              with:
-                  command: build
+              run: cargo build
     test:
         name: Test
         runs-on: ubuntu-latest
@@ -39,30 +31,11 @@ jobs:
             - name: Checkout sources
               uses: actions/checkout@v6
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '24'
+            # This job compares the expansion snapshots that the nightly
+            # workflow regenerates, so both must use the same cargo-expand.
+            - name: Setup test environment
+              uses: ./.github/actions/setup-test-env
 
-            - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-                  components: rustfmt
-
-            - name: Install wasm-pack
-              uses: jetli/wasm-pack-action@v0.4.0
-              with:
-                  # specify exact version to work around
-                  # https://github.com/jetli/wasm-pack-action/issues/23
-                  version: v0.14.0
-
-            - name: Add cargo-expand
-              run: cargo install cargo-expand
-
-            # Run the ./test.sh script
             - name: Test
               run: ./test.sh
     lint:
@@ -74,18 +47,10 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-                  components: rustfmt, clippy
+              run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --override
 
             - name: Cargo fmt
-              uses: actions-rs/cargo@v1
-              with:
-                  command: fmt
-                  args: --all -- --check
+              run: cargo fmt --all -- --check
 
             - name: Cargo clippy
               run: cargo clippy -- -D warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ Required tools: stable Rust, [wasm-pack](https://rustwasm.github.io/wasm-pack/),
 [cargo-expand](https://github.com/dtolnay/cargo-expand) (for the expand tests),
 and Node.js (for the wasm/e2e tests).
 
+CI pins cargo-expand to the version in `.github/actions/setup-test-env`. Its
+output shape feeds the snapshots, so regenerate them with that version.
+
 ## Expansion snapshots (`tests/expand/*.expanded.rs`)
 
 The snapshot files record the full macro expansion of `#[derive(Tsify)]`,


### PR DESCRIPTION
Follow-ups on the scheduled workflows from #87, found while reviewing them against what they actually guarantee.

- **Pin cargo-expand.** Its output shape feeds the snapshots, so an unpinned upgrade shows up as codegen drift and gets misattributed to a dependency release — exactly the signal this workflow exists to isolate.
- **Concurrency groups.** The bot branch is force-pushed and the tracking issue is decided per run, so a manual dispatch overlapping the nightly run could have them overwrite each other.
- **Stage before diffing.** `git diff --quiet -- tests` misses the snapshot for a newly added test, which stays untracked until staged.
- **Drop checkout credentials in latest-deps**, which only builds and tests.

Also unifies PR CI with the same setup action: the pin only covered half the pipeline, since PR CI compares the very snapshots the nightly workflow regenerates but installed its own unpinned cargo-expand. That removes the last uses of the archived `actions-rs/*` actions too.

Still open (bigger, kept separate): the expand workflow holds `contents/pull-requests/issues: write` for the whole job, including dependency resolution and the build. Splitting it into a read-only expand job that uploads the diff as an artifact and a write-scoped job that pushes would confine the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
