### PR TITLE
Release 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## v0.5.7
 
-- Added `Ts<T>`, a wrapper for `#[wasm_bindgen]` parameters and return types. `#[tsify(into_wasm_abi, from_wasm_abi)]` leak memory whenever (de)serialization fails: the conversion happens at the ABI boundary, where the only way to report failure is `wasm_bindgen::throw_str`, which does not run destructors. `Ts<T>` moves the conversion into the function body, where it is an ordinary `Result`. Resolves #65, #47 and #86. @cormacrelf contributed #71
-- Deprecated `into_wasm_abi` and `from_wasm_abi` in favour of `Ts<T>`. The README explains the mechanism; the attributes still work, and no removal is planned
+- Added `Ts<T>`, a wrapper for `#[wasm_bindgen]` parameters and return types. `#[tsify(from_wasm_abi)]` deserializes at the ABI boundary, which cannot report failure, so bad input from JavaScript ends in `wasm_bindgen::throw_str` — a catchable JS exception that skips destructors, leaking a little on every failure until the instance dies. `Ts<T>` keeps the boundary infallible and moves the conversion into the function body, where it is an ordinary `Result`. Resolves #65, #47 and #86. @cormacrelf contributed #71
+- Deprecated `into_wasm_abi` and `from_wasm_abi` in favour of `Ts<T>`. `into_wasm_abi` panics rather than leaks on failure, but it has the same root cause and the same fix. The attributes still work, and no removal is planned; see the README for details
+- Fixed a leak in `IntoWasmAbi for &Ts<T>`, which cloned the JS handle for a borrowed argument that the generated shim never releases
 - `Ts<T>` can now be returned from `async fn`. @hgiesel contributed #84
 - `#[tsify(namespace)]` enums now emit `export type E = E.A | E.B` instead of repeating each variant's shape in the union. @hgiesel contributed #78
 - Fixed raw string artifacts in doc comments copied into the generated TypeScript. @samkearney contributed the fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # tsify Changelog
 
+## v0.5.7
+
+- Added `Ts<T>`, a wrapper for `#[wasm_bindgen]` parameters and return types. `#[tsify(into_wasm_abi, from_wasm_abi)]` leak memory whenever (de)serialization fails: the conversion happens at the ABI boundary, where the only way to report failure is `wasm_bindgen::throw_str`, which does not run destructors. `Ts<T>` moves the conversion into the function body, where it is an ordinary `Result`. Resolves #65, #47 and #86. @cormacrelf contributed #71
+- Deprecated `into_wasm_abi` and `from_wasm_abi` in favour of `Ts<T>`. The README explains the mechanism; the attributes still work, and no removal is planned
+- `Ts<T>` can now be returned from `async fn`. @hgiesel contributed #84
+- `#[tsify(namespace)]` enums now emit `export type E = E.A | E.B` instead of repeating each variant's shape in the union. @hgiesel contributed #78
+- Fixed raw string artifacts in doc comments copied into the generated TypeScript. @samkearney contributed the fix
+
 ## v0.5.6
 
 - Resolve the issue with default parameters in generics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## v0.5.7
 
-- Added `Ts<T>`, a wrapper for `#[wasm_bindgen]` parameters and return types. `#[tsify(from_wasm_abi)]` deserializes at the ABI boundary, which cannot report failure, so bad input from JavaScript ends in `wasm_bindgen::throw_str` — a catchable JS exception that skips destructors, leaking a little on every failure until the instance dies. `Ts<T>` keeps the boundary infallible and moves the conversion into the function body, where it is an ordinary `Result`. Resolves #65, #47 and #86. @cormacrelf contributed #71
+- Added `Ts<T>`, a wrapper for `#[wasm_bindgen]` parameters and return types. `#[tsify(from_wasm_abi)]` deserializes at the ABI boundary, which cannot report failure, so bad input from JavaScript ends in `wasm_bindgen::throw_str` — a catchable JS exception that skips destructors, leaking a little on every failure until the instance dies. `Ts<T>` keeps the boundary infallible and moves the conversion into the function body, where it is an ordinary `Result`. Addresses #65, #47 and #86. @cormacrelf contributed #71
 - Deprecated `into_wasm_abi` and `from_wasm_abi` in favour of `Ts<T>`. `into_wasm_abi` panics rather than leaks on failure, but it has the same root cause and the same fix. The attributes still work, and no removal is planned; see the README for details
-- Fixed a leak in `IntoWasmAbi for &Ts<T>`, which cloned the JS handle for a borrowed argument that the generated shim never releases
 - `Ts<T>` can now be returned from `async fn`. @hgiesel contributed #84
 - `#[tsify(namespace)]` enums now emit `export type E = E.A | E.B` instead of repeating each variant's shape in the union. @hgiesel contributed #78
 - Fixed raw string artifacts in doc comments copied into the generated TypeScript. @samkearney contributed the fix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 authors = [
   "Madono Haru <madonoharu@gmail.com>",
@@ -14,7 +14,7 @@ keywords = ["wasm", "wasm-bindgen", "typescript"]
 categories = ["wasm"]
 
 [dependencies]
-tsify-macros = { path = "tsify-macros", version = "0.5.5" }
+tsify-macros = { path = "tsify-macros", version = "0.5.7" }
 wasm-bindgen = { version = "0.2.104", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ export interface Point {
     y: number;
 }
 
+
 export function from_js(point: Point): void;
 
 export function into_js(): Point;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Click to show Cargo.toml.
 
 ```toml
 [dependencies]
-tsify = "0.5.5"
+tsify = "0.5.7"
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2" }
 ```

--- a/README.md
+++ b/README.md
@@ -53,18 +53,14 @@ Will generate the following `.d.ts` file:
 ```ts
 /* tslint:disable */
 /* eslint-disable */
-/**
- * @returns {Point}
- */
-export function into_js(): Point;
-/**
- * @param {Point} point
- */
-export function from_js(point: Point): void;
 export interface Point {
     x: number;
     y: number;
 }
+
+export function from_js(point: Point): void;
+
+export function into_js(): Point;
 ```
 
 This is the behavior due to [`typescript_custom_section`](https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/on-rust-exports/typescript_custom_section.html) and [`Rust Type conversions`](https://rustwasm.github.io/docs/wasm-bindgen/contributing/design/rust-type-conversions.html).
@@ -233,12 +229,7 @@ declare namespace Color {
     };
 }
 
-export type Color =
-    | "Red"
-    | "Blue"
-    | "Green"
-    | { Rgb: [number, number, number] }
-    | { Hsv: { hue: number; saturation: number; value: number } };
+export type Color = Color.Red | Color.Blue | Color.Green | Color.Rgb | Color.Hsv;
 ```
 
 ## Type Aliases

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@ pub struct SerializationConfig {
 /// `Tsify` is a trait that allows you to convert a type to and from JavaScript.
 /// Can be implemented manually if you need to customize the serialization or deserialization.
 pub trait Tsify {
+    /// Must be a type imported through `#[wasm_bindgen] extern "C" { .. }`.
+    /// [`Ts<T>`] is `#[repr(transparent)]` over this and passes it across the
+    /// ABI as a plain JS handle, which any other representation would break.
     #[cfg(feature = "wasm-bindgen")]
     type JsType: JsCast;
 

--- a/src/ts.rs
+++ b/src/ts.rs
@@ -40,7 +40,6 @@ use wasm_bindgen::{JsCast, JsValue};
 ///    y: f64,
 /// }
 ///
-/// /// The panicking version
 /// #[wasm_bindgen]
 /// pub fn rotate(v: Ts<Vec2>, theta_rad: f64) -> Result<Ts<Vec2>, JsError> {
 ///     // Deserialize to rust type, throw deserialization error if fails
@@ -69,7 +68,7 @@ where
         Self(js, std::marker::PhantomData)
     }
 
-    /// Returns the inner JsValue representation. This is a zero cost operation.
+    /// Returns the inner JsValue representation, cloning the JS handle.
     pub fn js_value(&self) -> JsValue
     where
         <T as Tsify>::JsType: JsCast,
@@ -148,14 +147,16 @@ where
         self.0.into_abi()
     }
 }
-impl<T> IntoWasmAbi for &Ts<T>
+impl<'a, T> IntoWasmAbi for &'a Ts<T>
 where
     T: Tsify,
-    <T as Tsify>::JsType: IntoWasmAbi + Clone,
+    <T as Tsify>::JsType: JsCast + WasmDescribe,
 {
-    type Abi = <T::JsType as IntoWasmAbi>::Abi;
+    type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
+    // Borrowed, so the handle stays owned here. Cloning it would hand JS an
+    // extra table slot that the borrowed-argument shim never releases.
     fn into_abi(self) -> Self::Abi {
-        self.0.clone().into_abi()
+        self.0.unchecked_ref::<JsValue>().into_abi()
     }
 }
 impl<T> FromWasmAbi for Ts<T>

--- a/tests-e2e/build_all.sh
+++ b/tests-e2e/build_all.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Without this a failed `wasm-pack build` is followed by a successful `popd`,
+# so the script reports success and compare_output.sh then compares stale
+# artifacts.
+set -e
+
 # Define the root directory for the search
 ROOT_DIR="tests-e2e"
 

--- a/tests-e2e/reference_output/compare_output.sh
+++ b/tests-e2e/reference_output/compare_output.sh
@@ -38,6 +38,11 @@ for FOLDERNAME in $(find . -maxdepth 1 -type d); do
             else
                 echo "   Files are identical"
             fi
+        else
+            # A reference with no counterpart means the build stopped emitting
+            # it; skipping would report that regression as success.
+            echo "Missing generated file: $OTHER_FILE"
+            DIFF_FOUND=1
         fi
     done
 done

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -161,10 +161,10 @@ fn test_generics_with_default_params() {
     struct DeNamedTuple<A = i32, B = String, C = ()>(A, B, C);
 
     let expected = indoc! {r#"
-        export type SerNamedTuple<A, B, C> = [A, B, C];"#
+        export type DeNamedTuple<A, B, C> = [A, B, C];"#
     };
 
-    assert_eq!(SerNamedTuple::<(), (), ()>::DECL, expected);
+    assert_eq!(DeNamedTuple::<(), (), ()>::DECL, expected);
 
     #[derive(Serialize, Tsify)]
     #[tsify(into_wasm_abi)]

--- a/tsify-macros/Cargo.toml
+++ b/tsify-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify-macros"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 authors = [
     "Madono Haru <madonoharu@gmail.com>",


### PR DESCRIPTION
Prepares 0.5.7, the first release to contain `Ts<T>` — it landed in #71 after 0.5.6 was published, so the memory-leak fix has never reached anyone on crates.io.

## Both crates, in order

The `tsify-macros` floor moves from `0.5.5` to `0.5.7` along with the version bump. The published 0.5.6 macro predates the `Clone` derive on `JsType`, which `Ts<T>` relies on — so bumping only the root crate would let an existing lockfile keep resolving 0.5.6 and break `&Ts<T>` parameters, the form the README recommends. The workspace builds from path dependencies, so CI cannot catch that on its own.

Publishing therefore has to go macro-first: `tsify-macros` → wait for the index → `cargo publish --dry-run` on the root against the registry version → root → tag. `--dry-run` on the root currently fails with `failed to select a version for the requirement tsify-macros = "^0.5.7"`, which is the floor doing its job.

## Found while reviewing the release candidate

- **`IntoWasmAbi for &Ts<T>` leaked.** It cloned the JS handle, but the shim wasm-bindgen generates for a borrowed argument never releases it, so every `&Ts<T>` passed to an imported function dropped a table slot on the floor. wasm-bindgen's own extern types pass the handle by reference for exactly this reason; `Ts<T>` now does the same, and the `Clone` bound falls away with it.
- **The docs described code that doesn't exist.** Only `from_wasm_abi` reaches `throw_str` — `into_wasm_abi` panics — so the CHANGELOG's "both leak the same way" was wrong. The README's `#[tsify(namespace)]` example still showed the pre-#78 union, contradicting this release's own CHANGELOG entry, and its `.d.ts` example predated the current output shape. Both are now what a build actually emits.
- **The e2e gate let failures through.** `build_all.sh` had no `set -e`, so a failed `wasm-pack build` was followed by a successful `popd`; `compare_output.sh` skipped any reference whose generated counterpart was missing. Together those two turned a completely failed e2e build into a green run. A generics test also asserted `SerNamedTuple` where it meant `DeNamedTuple`.

## Also

- README's install snippet said `tsify = "0.5.5"` while demonstrating `Ts<T>`, which does not exist in 0.5.5 or 0.5.6.
- `Tsify::JsType` now documents the contract the ABI impls already assume: it has to be a `#[wasm_bindgen] extern "C"` type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
