### PR TITLE
Add #[tsify(rename)], and stop the affix reaching names it does not own

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Tsify container attributes
 -   `namespace` generates a namespace for the enum variants.
 -   `type` overrides at the container level.
 -   `type_params` overrides params at the container level.
+-   `type_prefix = "Pre"` and `type_suffix = "Suf"` add a universal affix to the names of generated types. Apply them crate-wide: a reference takes the affix of the type doing the referencing, so applying either to only some of your types emits references to names that were never declared ([#94](https://github.com/madonoharu/tsify/issues/94)).
+-   `rename = "NewName"` changes the name of the generated TypeScript declaration. References are unaffected — point them at the new name with `#[tsify(type = "NewName")]` where another type refers to this one ([#103](https://github.com/madonoharu/tsify/issues/103) covers what it would take for references to follow). Cannot be combined with `type_prefix` or `type_suffix`.
 
 [Serializer configuration options](https://github.com/RReverser/serde-wasm-bindgen?tab=readme-ov-file#serializer-configuration-options)
 -   `missing_as_null` 

--- a/tests/affixes.rs
+++ b/tests/affixes.rs
@@ -2,6 +2,8 @@
 
 use indoc::indoc;
 use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tsify::Tsify;
 
 #[test]
@@ -111,6 +113,227 @@ fn test_prefix_suffix() {
         DoubleAffixedEnum::DECL,
         indoc! {"
             export type PreDoubleAffixedEnumSuf = { VariantA: PreMyTypeSuf } | { VariantB: number };"
+        }
+    );
+}
+
+#[test]
+fn test_affix_leaves_type_parameters_alone() {
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Ts")]
+    struct PrefixedGeneric<T> {
+        x: T,
+        y: u32,
+    }
+
+    assert_eq!(
+        PrefixedGeneric::<u32>::DECL,
+        indoc! {"
+            export interface TsPrefixedGeneric<T> {
+                x: T;
+                y: number;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(type_suffix = "Sfx")]
+    struct SuffixedGeneric<T> {
+        x: T,
+    }
+
+    assert_eq!(
+        SuffixedGeneric::<u32>::DECL,
+        indoc! {"
+            export interface SuffixedGenericSfx<T> {
+                x: T;
+            }"
+        }
+    );
+
+    #[derive(Tsify)]
+    #[tsify(namespace, type_prefix = "Ts")]
+    enum PrefixedGenericEnum<T> {
+        A(T),
+        B(u32),
+    }
+
+    assert_eq!(
+        PrefixedGenericEnum::<u32>::DECL,
+        indoc! {"
+            declare namespace TsPrefixedGenericEnum {
+                export type A<T> = { A: T };
+                export type B = { B: number };
+            }
+
+            export type TsPrefixedGenericEnum<T> = TsPrefixedGenericEnum.A<T> | TsPrefixedGenericEnum.B;"
+        }
+    );
+}
+
+#[test]
+fn test_affix_leaves_nested_type_parameters_alone() {
+    type MyAlias = u32;
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Ts")]
+    struct Nested<T, K, V> {
+        vector: Vec<T>,
+        map: HashMap<K, V>,
+        optional: Option<T>,
+        tuple: (T, MyAlias),
+        boxed: Box<T>,
+        function: fn(T) -> Option<T>,
+        deeply_nested: Option<Vec<Box<T>>>,
+    }
+
+    let expected = if cfg!(feature = "js") {
+        indoc! {"
+            export interface TsNested<T, K, V> {
+                vector: T[];
+                map: Map<K, V>;
+                optional: T | undefined;
+                tuple: [T, TsMyAlias];
+                boxed: T;
+                function: (arg0: T) => T | undefined;
+                deeply_nested: T[] | undefined;
+            }"
+        }
+    } else {
+        indoc! {"
+            export interface TsNested<T, K, V> {
+                vector: T[];
+                map: Record<K, V>;
+                optional: T | null;
+                tuple: [T, TsMyAlias];
+                boxed: T;
+                function: (arg0: T) => T | null;
+                deeply_nested: T[] | null;
+            }"
+        }
+    };
+
+    assert_eq!(Nested::<u32, String, bool>::DECL, expected);
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Ts")]
+    struct Mixed<T> {
+        param: T,
+        real: MyAlias,
+    }
+
+    assert_eq!(
+        Mixed::<u32>::DECL,
+        indoc! {"
+            export interface TsMixed<T> {
+                param: T;
+                real: TsMyAlias;
+            }"
+        }
+    );
+}
+
+#[test]
+fn test_affix_nested_generic_namespace() {
+    struct Wrapper<T>(T);
+
+    #[derive(Tsify)]
+    #[tsify(namespace, type_prefix = "Ts")]
+    enum NestedNamespace<T> {
+        Wrapped(Wrapper<Vec<T>>),
+        Empty,
+    }
+
+    assert_eq!(
+        NestedNamespace::<u32>::DECL,
+        indoc! {r#"
+            type __TsNestedNamespaceTsWrapper<A> = TsWrapper<A>;
+            declare namespace TsNestedNamespace {
+                export type Wrapped<T> = { Wrapped: __TsNestedNamespaceTsWrapper<T[]> };
+                export type Empty = "Empty";
+            }
+
+            export type TsNestedNamespace<T> = TsNestedNamespace.Wrapped<T> | TsNestedNamespace.Empty;"#
+        }
+    );
+}
+
+#[test]
+fn test_affix_leaves_the_wire_tag_alone() {
+    #[derive(Tsify, Serialize, Deserialize)]
+    #[serde(tag = "kind")]
+    #[tsify(type_prefix = "A")]
+    struct Config {
+        x: i32,
+    }
+
+    assert_eq!(
+        Config::DECL,
+        indoc! {r#"
+            export interface AConfig {
+                kind: "Config";
+                x: number;
+            }"#
+        }
+    );
+
+    // The tag literal is a value serde writes, so pin it against serde rather than
+    // against itself: the two cannot drift apart without this noticing.
+    let json = serde_json::to_string(&Config { x: 1 }).unwrap();
+    assert!(json.contains(r#""kind":"Config""#), "serde wrote {json}");
+
+    // `#[serde(rename)]` still reaches the tag, since that one does change the wire.
+    #[derive(Tsify, Serialize, Deserialize)]
+    #[serde(tag = "kind", rename = "WireName")]
+    #[tsify(type_prefix = "A")]
+    struct Renamed {
+        x: i32,
+    }
+
+    assert_eq!(
+        Renamed::DECL,
+        indoc! {r#"
+            export interface ARenamed {
+                kind: "WireName";
+                x: number;
+            }"#
+        }
+    );
+}
+
+#[test]
+fn test_crate_wide_affix_resolves_generic_references() {
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Ts")]
+    struct Inner<T> {
+        x: T,
+    }
+
+    #[derive(Tsify)]
+    #[tsify(type_prefix = "Ts")]
+    struct Outer<T, U> {
+        one: Inner<T>,
+        other: Inner<U>,
+        many: Vec<Inner<T>>,
+    }
+
+    assert_eq!(
+        Inner::<u32>::DECL,
+        indoc! {"
+            export interface TsInner<T> {
+                x: T;
+            }"
+        }
+    );
+
+    assert_eq!(
+        Outer::<u32, bool>::DECL,
+        indoc! {"
+            export interface TsOuter<T, U> {
+                one: TsInner<T>;
+                other: TsInner<U>;
+                many: TsInner<T>[];
+            }"
         }
     );
 }

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -1,0 +1,255 @@
+use indoc::{formatdoc, indoc};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+struct TempCrate(PathBuf);
+
+struct CompileFailCase {
+    module: &'static str,
+    source: &'static str,
+    line: usize,
+    message: &'static str,
+}
+
+impl TempCrate {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after the Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "tsify-rename-compile-fail-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(path.join("src")).expect("failed to create temporary test crate");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TempCrate {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn assert_diagnostic(stderr: &str, case: &CompileFailCase) {
+    let error = format!("error: {}", case.message);
+    let location = format!("--> src/{}.rs:{}:", case.module, case.line);
+    let mut search_start = 0;
+
+    while let Some(relative_start) = stderr[search_start..].find(&error) {
+        let error_start = search_start + relative_start;
+        let diagnostic = &stderr[error_start..];
+        let diagnostic_end = diagnostic[1..]
+            .find("\nerror:")
+            .map_or(diagnostic.len(), |index| index + 1);
+        let diagnostic = &diagnostic[..diagnostic_end];
+
+        if diagnostic.contains(&location) {
+            return;
+        }
+        search_start = error_start + error.len();
+    }
+
+    panic!(
+        "missing diagnostic for {} at line {}: {}\n{stderr}",
+        case.module, case.line, case.message
+    );
+}
+
+#[test]
+fn invalid_rename_attributes_fail_to_compile() {
+    let temp_crate = TempCrate::new();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dependency_path = manifest_dir.to_string_lossy().replace('\\', "\\\\");
+    let manifest = formatdoc! {r#"
+        [package]
+        name = "tsify-rename-compile-fail"
+        version = "0.0.0"
+        edition = "2021"
+
+        [dependencies]
+        tsify = {{ path = "{dependency_path}" }}
+
+        [workspace]
+    "#};
+    fs::write(temp_crate.path().join("Cargo.toml"), manifest)
+        .expect("failed to write temporary Cargo.toml");
+    let cases = [
+        CompileFailCase {
+            module: "duplicate_same_attribute",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "First", rename = "Second")]
+                struct DuplicateSameAttribute;
+            "#},
+            line: 4,
+            message: "duplicate attribute",
+        },
+        CompileFailCase {
+            module: "duplicate_separate_attributes",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "First")]
+                #[tsify(rename = "Second")]
+                struct DuplicateSeparateAttributes;
+            "#},
+            line: 5,
+            message: "duplicate attribute",
+        },
+        CompileFailCase {
+            module: "empty",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "")]
+                struct Empty;
+            "#},
+            line: 4,
+            message: "`rename` must be a valid TypeScript identifier",
+        },
+        CompileFailCase {
+            module: "leading_digit",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "1Name")]
+                struct LeadingDigit;
+            "#},
+            line: 4,
+            message: "`rename` must be a valid TypeScript identifier",
+        },
+        CompileFailCase {
+            module: "invalid_character",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "not-valid")]
+                struct InvalidCharacter;
+            "#},
+            line: 4,
+            message: "`rename` must be a valid TypeScript identifier",
+        },
+        CompileFailCase {
+            module: "non_string",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = 123)]
+                struct NonString;
+            "#},
+            line: 4,
+            message: "expected string literal",
+        },
+        CompileFailCase {
+            module: "value_missing",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename)]
+                struct ValueMissing;
+            "#},
+            line: 4,
+            message: "expected `=`",
+        },
+        CompileFailCase {
+            module: "rename_then_prefix",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "Renamed", type_prefix = "Prefix")]
+                struct RenameThenPrefix;
+            "#},
+            line: 4,
+            message: "`rename` cannot be combined with `type_prefix` or `type_suffix`",
+        },
+        CompileFailCase {
+            module: "prefix_then_rename",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(type_prefix = "Prefix", rename = "Renamed")]
+                struct PrefixThenRename;
+            "#},
+            line: 4,
+            message: "`rename` cannot be combined with `type_prefix` or `type_suffix`",
+        },
+        CompileFailCase {
+            module: "rename_then_suffix",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(rename = "Renamed", type_suffix = "Suffix")]
+                struct RenameThenSuffix;
+            "#},
+            line: 4,
+            message: "`rename` cannot be combined with `type_prefix` or `type_suffix`",
+        },
+        CompileFailCase {
+            module: "suffix_then_rename",
+            source: indoc! {r#"
+                use tsify::Tsify;
+
+                #[derive(Tsify)]
+                #[tsify(type_suffix = "Suffix", rename = "Renamed")]
+                struct SuffixThenRename;
+            "#},
+            line: 4,
+            message: "`rename` cannot be combined with `type_prefix` or `type_suffix`",
+        },
+    ];
+    let modules = cases
+        .iter()
+        .map(|case| format!("mod {};", case.module))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(temp_crate.path().join("src/lib.rs"), modules)
+        .expect("failed to write temporary lib.rs");
+    for case in &cases {
+        fs::write(
+            temp_crate
+                .path()
+                .join("src")
+                .join(format!("{}.rs", case.module)),
+            case.source,
+        )
+        .unwrap_or_else(|error| panic!("failed to write {} fixture: {error}", case.module));
+    }
+
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(cargo)
+        .args(["check", "--offline", "--quiet"])
+        .current_dir(temp_crate.path())
+        .env(
+            "CARGO_TARGET_DIR",
+            manifest_dir.join("target/tests/compile-fail"),
+        )
+        .output()
+        .expect("failed to execute cargo check for compile-fail cases");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(!output.status.success(), "fixture unexpectedly compiled");
+    for case in &cases {
+        assert_diagnostic(&stderr, case);
+    }
+}

--- a/tests/expand/rename.expanded.rs
+++ b/tests/expand/rename.expanded.rs
@@ -1,0 +1,239 @@
+use tsify::Tsify;
+#[tsify(rename = "RenamedWasmType")]
+pub struct RustType {
+    value: String,
+}
+const _: () = {
+    use tsify::Tsify;
+    use wasm_bindgen::{
+        convert::{
+            FromWasmAbi, VectorFromWasmAbi, IntoWasmAbi, VectorIntoWasmAbi,
+            OptionFromWasmAbi, OptionIntoWasmAbi, RefFromWasmAbi,
+        },
+        describe::WasmDescribe, describe::WasmDescribeVector, prelude::*,
+    };
+    #[repr(transparent)]
+    pub struct JsType {
+        obj: wasm_bindgen::JsValue,
+    }
+    #[automatically_derived]
+    impl ::core::clone::Clone for JsType {
+        #[inline]
+        fn clone(&self) -> JsType {
+            JsType {
+                obj: ::core::clone::Clone::clone(&self.obj),
+            }
+        }
+    }
+    #[automatically_derived]
+    const _: () = {
+        use wasm_bindgen::convert::TryFromJsValue;
+        use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+        use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
+        use wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
+        use wasm_bindgen::describe::WasmDescribe;
+        use wasm_bindgen::{JsValue, JsCast};
+        use wasm_bindgen::__rt::{core, marker::ErasableGeneric};
+        #[automatically_derived]
+        impl WasmDescribe for JsType {
+            fn describe() {
+                use wasm_bindgen::describe::*;
+                inform(NAMED_EXTERNREF);
+                inform(15u32);
+                inform(82u32);
+                inform(101u32);
+                inform(110u32);
+                inform(97u32);
+                inform(109u32);
+                inform(101u32);
+                inform(100u32);
+                inform(87u32);
+                inform(97u32);
+                inform(115u32);
+                inform(109u32);
+                inform(84u32);
+                inform(121u32);
+                inform(112u32);
+                inform(101u32);
+            }
+        }
+        #[automatically_derived]
+        impl IntoWasmAbi for JsType {
+            type Abi = <JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                self.obj.into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl OptionIntoWasmAbi for JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> OptionIntoWasmAbi for &'a JsType {
+            #[inline]
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        #[automatically_derived]
+        impl FromWasmAbi for JsType {
+            type Abi = <JsValue as FromWasmAbi>::Abi;
+            #[inline]
+            unsafe fn from_abi(js: Self::Abi) -> Self {
+                JsType {
+                    obj: JsValue::from_abi(js).into(),
+                }
+            }
+        }
+        #[automatically_derived]
+        impl OptionFromWasmAbi for JsType {
+            #[inline]
+            fn is_none(abi: &Self::Abi) -> bool {
+                *abi == 0
+            }
+        }
+        #[automatically_derived]
+        impl<'a> IntoWasmAbi for &'a JsType {
+            type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
+            #[inline]
+            fn into_abi(self) -> Self::Abi {
+                (&self.obj).into_abi()
+            }
+        }
+        #[automatically_derived]
+        impl RefFromWasmAbi for JsType {
+            type Abi = <JsValue as RefFromWasmAbi>::Abi;
+            type Anchor = wasm_bindgen::__rt::core::mem::ManuallyDrop<JsType>;
+            #[inline]
+            unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as RefFromWasmAbi>::ref_from_abi(js);
+                wasm_bindgen::__rt::core::mem::ManuallyDrop::new(JsType {
+                    obj: wasm_bindgen::__rt::core::mem::ManuallyDrop::into_inner(tmp)
+                        .into(),
+                })
+            }
+        }
+        #[automatically_derived]
+        impl LongRefFromWasmAbi for JsType {
+            type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
+            type Anchor = JsType;
+            #[inline]
+            unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                let tmp = <JsValue as LongRefFromWasmAbi>::long_ref_from_abi(js);
+                JsType { obj: tmp.into() }
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsValue> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsValue {
+                self.obj.as_ref()
+            }
+        }
+        #[automatically_derived]
+        impl AsRef<JsType> for JsType {
+            #[inline]
+            fn as_ref(&self) -> &JsType {
+                self
+            }
+        }
+        #[automatically_derived]
+        impl wasm_bindgen::IntoJsGeneric for JsType
+        where
+            JsType: wasm_bindgen::JsGeneric,
+        {
+            type JsCanon = JsType;
+            #[inline]
+            fn to_js(self) -> JsType {
+                unsafe {
+                    wasm_bindgen::__rt::core::mem::transmute_copy(
+                        &wasm_bindgen::__rt::core::mem::ManuallyDrop::new(self),
+                    )
+                }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsValue> for JsType {
+            #[inline]
+            fn from(obj: JsValue) -> Self {
+                JsType { obj: obj.into() }
+            }
+        }
+        #[automatically_derived]
+        impl From<JsType> for JsValue {
+            #[inline]
+            fn from(obj: JsType) -> JsValue {
+                obj.obj.into()
+            }
+        }
+        #[automatically_derived]
+        impl JsCast for JsType {
+            fn instanceof(val: &JsValue) -> bool {
+                unsafe fn __wbg_instanceof_JsType_07a4c56f90e9a47b(_: u32) -> u32 {
+                    {
+                        ::core::panicking::panic_fmt(
+                            format_args!("cannot check instanceof on non-wasm targets"),
+                        );
+                    };
+                }
+                unsafe {
+                    let idx = val.into_abi();
+                    __wbg_instanceof_JsType_07a4c56f90e9a47b(idx) != 0
+                }
+            }
+            #[inline]
+            fn unchecked_from_js(val: JsValue) -> Self {
+                JsType { obj: val.into() }
+            }
+            #[inline]
+            fn unchecked_from_js_ref(val: &JsValue) -> &Self {
+                unsafe { &*(val as *const JsValue as *const Self) }
+            }
+        }
+        unsafe impl ErasableGeneric for JsType {
+            type Repr = JsValue;
+        }
+    };
+    #[automatically_derived]
+    impl wasm_bindgen::sys::Promising for JsType {
+        type Resolution = JsType;
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::__rt::core::ops::Deref for JsType {
+        type Target = wasm_bindgen::JsValue;
+        #[inline]
+        fn deref(&self) -> &wasm_bindgen::JsValue {
+            &self.obj
+        }
+    }
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for wasm_bindgen::JsValue {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<wasm_bindgen::JsValue> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType> for JsType {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsOption<JsType> {}
+    #[automatically_derived]
+    impl wasm_bindgen::convert::UpcastFrom<JsType>
+    for wasm_bindgen::sys::JsNullable<JsType> {}
+    #[automatically_derived]
+    impl Tsify for RustType {
+        type JsType = JsType;
+        const DECL: &'static str = "export interface RenamedWasmType {\n    value: string;\n}";
+        const SERIALIZATION_CONFIG: tsify::SerializationConfig = tsify::SerializationConfig {
+            missing_as_null: false,
+            hashmap_as_object: false,
+            large_number_types_as_bigints: false,
+        };
+    }
+};

--- a/tests/expand/rename.rs
+++ b/tests/expand/rename.rs
@@ -1,0 +1,7 @@
+use tsify::Tsify;
+
+#[derive(Tsify)]
+#[tsify(rename = "RenamedWasmType")]
+pub struct RustType {
+    value: String,
+}

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -65,6 +65,239 @@ fn test_rename() {
 }
 
 #[test]
+fn test_tsify_container_rename() {
+    #[derive(Tsify)]
+    #[tsify(rename = "StructDeclaration")]
+    struct RustStruct {
+        value: String,
+    }
+
+    #[derive(Tsify)]
+    #[tsify(rename = "EnumDeclaration")]
+    enum RustEnum {
+        Variant(bool),
+    }
+
+    assert_eq!(
+        RustStruct::DECL,
+        indoc! {"
+            export interface StructDeclaration {
+                value: string;
+            }"
+        }
+    );
+    assert_eq!(
+        RustEnum::DECL,
+        "export type EnumDeclaration = { Variant: boolean };"
+    );
+}
+
+#[test]
+fn test_tsify_container_rename_overrides_serde_rename() {
+    #[derive(Tsify)]
+    #[serde(rename = "SerdeDeclaration")]
+    #[tsify(rename = "TsifyDeclaration")]
+    struct RustDeclaration {
+        value: String,
+    }
+
+    assert_eq!(
+        RustDeclaration::DECL,
+        indoc! {"
+            export interface TsifyDeclaration {
+                value: string;
+            }"
+        }
+    );
+}
+
+#[test]
+fn test_tsify_container_rename_does_not_change_internal_tag_value() {
+    #[derive(Tsify)]
+    #[serde(rename = "WireName", tag = "kind")]
+    #[tsify(rename = "DeclarationName")]
+    struct RustName {
+        value: String,
+    }
+
+    assert_eq!(
+        RustName::DECL,
+        indoc! {r#"
+            export interface DeclarationName {
+                kind: "WireName";
+                value: string;
+            }"#
+        }
+    );
+}
+
+#[test]
+fn test_tsify_container_rename_currently_requires_reference_override() {
+    // `rename` names declarations and nothing else. Both references sit side by side
+    // so that #103, if it lands, has to change this expectation deliberately.
+    #[derive(Tsify)]
+    #[tsify(rename = "PublicConfig")]
+    struct Config {
+        value: String,
+    }
+
+    #[derive(Tsify)]
+    struct Holder {
+        config: Config,
+        #[tsify(type = "PublicConfig")]
+        fixed_config: Config,
+    }
+
+    assert_eq!(
+        Config::DECL,
+        indoc! {"
+            export interface PublicConfig {
+                value: string;
+            }"
+        }
+    );
+    assert_eq!(
+        Holder::DECL,
+        indoc! {"
+            export interface Holder {
+                config: Config;
+                fixed_config: PublicConfig;
+            }"
+        }
+    );
+}
+
+#[test]
+fn test_tsify_container_rename_namespace_with_generics() {
+    struct Wrapper<T>(T);
+
+    #[derive(Tsify)]
+    #[tsify(namespace, rename = "PublicResult")]
+    enum RustResult<T> {
+        Value(Wrapper<Vec<T>>),
+        Empty,
+    }
+
+    assert_eq!(
+        RustResult::<u32>::DECL,
+        indoc! {r#"
+            type __PublicResultWrapper<A> = Wrapper<A>;
+            declare namespace PublicResult {
+                export type Value<T> = { Value: __PublicResultWrapper<T[]> };
+                export type Empty = "Empty";
+            }
+
+            export type PublicResult<T> = PublicResult.Value<T> | PublicResult.Empty;"#
+        }
+    );
+}
+
+#[test]
+fn test_tsify_container_rename_declaration_forms() {
+    struct Unsupported;
+
+    #[derive(Tsify)]
+    #[tsify(rename = "RenamedNewtype")]
+    struct RustNewtype(u32);
+
+    #[derive(Tsify)]
+    #[tsify(rename = "RenamedUnit")]
+    struct RustUnit;
+
+    #[derive(Tsify)]
+    #[serde(transparent)]
+    #[tsify(rename = "RenamedTransparent")]
+    struct RustTransparent(String);
+
+    #[derive(Tsify)]
+    #[tsify(rename = "RenamedOverride", type = "{ value: string }")]
+    struct RustOverride(Unsupported);
+
+    assert_eq!(
+        RustNewtype::DECL,
+        indoc! {"
+            export type RenamedNewtype = number;"
+        }
+    );
+    assert_eq!(
+        RustUnit::DECL,
+        if cfg!(feature = "js") {
+            indoc! {"
+                export type RenamedUnit = undefined;"
+            }
+        } else {
+            indoc! {"
+                export type RenamedUnit = null;"
+            }
+        }
+    );
+    assert_eq!(
+        RustTransparent::DECL,
+        indoc! {"
+            export type RenamedTransparent = string;"
+        }
+    );
+    assert_eq!(
+        RustOverride::DECL,
+        indoc! {"
+            export type RenamedOverride = { value: string };"
+        }
+    );
+}
+
+#[test]
+fn test_tsify_container_rename_serde_tag_strategies() {
+    #[derive(Tsify)]
+    #[serde(tag = "kind")]
+    #[tsify(rename = "RenamedInternal")]
+    enum RustInternal<T> {
+        Value { value: T },
+        Empty,
+    }
+
+    #[derive(Tsify)]
+    #[serde(tag = "kind", content = "content")]
+    #[tsify(rename = "RenamedAdjacent")]
+    enum RustAdjacent<T> {
+        Value(T),
+        Empty,
+    }
+
+    #[derive(Tsify)]
+    #[serde(untagged)]
+    #[tsify(rename = "RenamedUntagged")]
+    enum RustUntagged<T> {
+        Value(T),
+        Empty,
+    }
+
+    assert_eq!(
+        RustInternal::<String>::DECL,
+        indoc! {r#"
+            export type RenamedInternal<T> = { kind: "Value"; value: T } | { kind: "Empty" };"#
+        }
+    );
+    assert_eq!(
+        RustAdjacent::<String>::DECL,
+        indoc! {r#"
+            export type RenamedAdjacent<T> = { kind: "Value"; content: T } | { kind: "Empty" };"#
+        }
+    );
+    assert_eq!(
+        RustUntagged::<String>::DECL,
+        if cfg!(feature = "js") {
+            indoc! {"
+                export type RenamedUntagged<T> = T | undefined;"
+            }
+        } else {
+            indoc! {"
+                export type RenamedUntagged<T> = T | null;"
+            }
+        }
+    );
+}
+
+#[test]
 fn test_rename_all() {
     /// Comment for Enum
     #[allow(clippy::enum_variant_names)]

--- a/tsify-macros/Cargo.toml
+++ b/tsify-macros/Cargo.toml
@@ -20,6 +20,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", default-features = false, features = [
+    "extra-traits",
     "full",
     "parsing",
     "printing",

--- a/tsify-macros/src/attrs.rs
+++ b/tsify-macros/src/attrs.rs
@@ -8,6 +8,8 @@ use syn::spanned::Spanned;
 pub struct TsifyContainerAttrs {
     pub type_override: Option<String>,
     pub type_params: Option<Vec<String>>,
+    /// The name of the generated Typescript declaration.
+    pub rename: Option<String>,
     /// Implement `IntoWasmAbi` for the type.
     pub into_wasm_abi: bool,
     /// Implement `FromWasmAbi` for the type.
@@ -50,9 +52,11 @@ impl TypeGenerationConfig {
 
 impl TsifyContainerAttrs {
     pub fn from_derive_input(input: &syn::DeriveInput) -> syn::Result<Self> {
+        let mut rename_span = None;
         let mut attrs = Self {
             type_override: None,
             type_params: None,
+            rename: None,
             into_wasm_abi: false,
             from_wasm_abi: false,
             from_wasm_abi_span: None,
@@ -82,6 +86,23 @@ impl TsifyContainerAttrs {
                     }
                     let lit = meta.value()?.parse::<syn::LitStr>()?;
                     attrs.type_params = Some(lit.value().split(',').map(|s| s.trim().to_string()).collect());
+                    return Ok(());
+                }
+
+                if meta.path.is_ident("rename") {
+                    if attrs.rename.is_some() {
+                        return Err(meta.error("duplicate attribute"));
+                    }
+                    let lit = meta.value()?.parse::<syn::LitStr>()?;
+                    let rename = lit.value();
+                    if !is_ts_identifier(&rename) {
+                        return Err(syn::Error::new(
+                            lit.span(),
+                            "`rename` must be a valid TypeScript identifier",
+                        ));
+                    }
+                    attrs.rename = Some(rename);
+                    rename_span = Some(meta.path.span());
                     return Ok(());
                 }
 
@@ -171,12 +192,29 @@ impl TsifyContainerAttrs {
                     return Ok(());
                 }
 
-                Err(meta.error("unsupported tsify attribute, expected one of `type`, `type_params`, `into_wasm_abi`, `from_wasm_abi`, `namespace`, `type_prefix`, `type_suffix`, `missing_as_null`, `hashmap_as_object`, `large_number_types_as_bigints`"))
+                Err(meta.error("unsupported tsify attribute, expected one of `type`, `type_params`, `rename`, `into_wasm_abi`, `from_wasm_abi`, `namespace`, `type_prefix`, `type_suffix`, `missing_as_null`, `hashmap_as_object`, `large_number_types_as_bigints`"))
             })?;
+        }
+
+        if attrs.rename.is_some()
+            && (attrs.ty_config.type_prefix.is_some() || attrs.ty_config.type_suffix.is_some())
+        {
+            return Err(syn::Error::new(
+                rename_span.unwrap_or_else(Span::call_site),
+                "`rename` cannot be combined with `type_prefix` or `type_suffix`",
+            ));
         }
 
         Ok(attrs)
     }
+}
+
+fn is_ts_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_' || c == '$')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
 }
 
 #[derive(Debug, Default)]

--- a/tsify-macros/src/container.rs
+++ b/tsify-macros/src/container.rs
@@ -11,9 +11,9 @@ pub struct Container<'a> {
     pub attrs: TsifyContainerAttrs,
     /// Information about the type as parsed by Serde.
     pub serde_container: SerdeContainer<'a>,
-    /// The `ident` of the type as written in the Rust code.
+    /// The `ident` of the type, with `type_prefix` and `type_suffix` applied.
     pub ident_str: String,
-    /// The name type that will be serialized to Typescript.
+    /// The name serde serializes the type under.
     pub name: String,
 }
 
@@ -31,9 +31,10 @@ impl<'a> Container<'a> {
             }
         };
 
-        let name = attrs
-            .ty_config
-            .format_name(serde_container.attrs.name().serialize_name().to_string());
+        // No affix: this is the value serde writes, and serde knows nothing about
+        // `type_prefix` or `type_suffix`. Every other wire-facing name -- variant tags,
+        // field keys -- already comes straight from serde.
+        let name = serde_container.attrs.name().serialize_name().to_string();
 
         let ident_str = attrs
             .ty_config
@@ -67,9 +68,17 @@ impl<'a> Container<'a> {
         &self.serde_container.ident
     }
 
-    /// The `ident` of the type as written in the Rust code as a string.
+    /// The `ident` of the type as a string, with `type_prefix` and `type_suffix` applied.
     pub fn ident_str(&self) -> String {
         self.ident_str.clone()
+    }
+
+    /// The name of the generated declaration -- not `name()`, which reaches the wire.
+    pub fn declaration_name(&self) -> String {
+        self.attrs
+            .rename
+            .clone()
+            .unwrap_or_else(|| self.ident_str())
     }
 
     #[inline]
@@ -82,7 +91,8 @@ impl<'a> Container<'a> {
         self.serde_attrs().transparent()
     }
 
-    /// The name of the type that will be serialized to Typescript.
+    /// The name serde serializes the type under. This is wire data rather than a type
+    /// name, so no affix is applied.
     pub fn name(&self) -> String {
         self.name.clone()
     }

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -4,7 +4,7 @@ use std::{fmt::Display, vec};
 use crate::comments::clean_comments;
 use crate::{
     comments::write_doc_comments,
-    typescript::{TsType, TsTypeElement, TsTypeLit},
+    typescript::{TsType, TsTypeElement, TsTypeLit, TsTypeRef, TsTypeRefSource},
 };
 
 #[derive(Debug, Clone)]
@@ -121,20 +121,22 @@ fn tparam(i: usize) -> String {
 impl TsEnumDecl {
     fn replace_type_params(ts_type: TsType, type_args: &mut Vec<String>) -> TsType {
         match ts_type {
-            TsType::Ref { name, type_params } => TsType::Ref {
-                name,
-                type_params: type_params
+            TsType::Ref(type_ref) => TsType::Ref(TsTypeRef {
+                type_params: type_ref
+                    .type_params
                     .iter()
                     .map(|_| {
                         let name = tparam(type_args.len());
                         type_args.push(name.clone());
-                        TsType::Ref {
+                        TsType::Ref(TsTypeRef {
                             name,
+                            source: TsTypeRefSource::TypeParam,
                             type_params: Vec::new(),
-                        }
+                        })
                     })
                     .collect(),
-            },
+                ..type_ref
+            }),
             TsType::Array(t) => TsType::Array(Box::new(TsEnumDecl::replace_type_params(
                 t.deref().clone(),
                 type_args,
@@ -200,19 +202,16 @@ impl Display for TsEnumDecl {
 
                     type_refs
                         .iter()
-                        .filter(|(name, _)| !self.type_params.contains(name))
-                        .map(|(name, type_args)| {
+                        .filter(|type_ref| !self.type_params.contains(&type_ref.name))
+                        .map(|type_ref| {
                             let mut type_refs = Vec::new();
                             let ts_type = TsEnumDecl::replace_type_params(
-                                TsType::Ref {
-                                    name: name.clone(),
-                                    type_params: type_args.clone(),
-                                },
+                                TsType::Ref(type_ref.clone()),
                                 &mut type_refs,
                             );
 
                             TsTypeAliasDecl {
-                                id: format!("__{}{}", self.id, name),
+                                id: format!("__{}{}", self.id, type_ref.name),
                                 export: false,
                                 type_params: type_refs,
                                 type_ann: ts_type,
@@ -279,10 +278,11 @@ impl Display for TsEnumDecl {
                                 format!("{}.{}<{}>", self.id, clone.id, type_params)
                             };
 
-                            TsType::Ref {
+                            TsType::Ref(TsTypeRef {
                                 name,
+                                source: TsTypeRefSource::Synthetic,
                                 type_params: vec![],
-                            }
+                            })
                         } else {
                             clone.type_ann.clone()
                         }

--- a/tsify-macros/src/parser.rs
+++ b/tsify-macros/src/parser.rs
@@ -10,7 +10,7 @@ use crate::{
     comments::extract_doc_comments,
     container::Container,
     decl::{Decl, TsEnumDecl, TsInterfaceDecl, TsTypeAliasDecl},
-    typescript::{TsType, TsTypeElement, TsTypeLit},
+    typescript::{TsType, TsTypeElement, TsTypeLit, TypeContext},
 };
 
 enum ParsedFields {
@@ -82,7 +82,7 @@ impl<'a> Parser<'a> {
 
     fn create_type_alias_decl(&self, type_ann: TsType) -> Decl {
         Decl::TsTypeAlias(TsTypeAliasDecl {
-            id: self.container.ident_str(),
+            id: self.container.declaration_name(),
             export: true,
             type_params: self
                 .container
@@ -116,7 +116,7 @@ impl<'a> Parser<'a> {
                 .unwrap_or_else(|| self.create_relevant_type_params(type_ref_names));
 
             Decl::TsInterface(TsInterfaceDecl {
-                id: self.container.ident_str(),
+                id: self.container.declaration_name(),
                 type_params,
                 extends,
                 body: members,
@@ -213,7 +213,13 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let type_ann = TsType::from_syn_type(&self.container.attrs.ty_config, field.ty);
+        let type_ann = TsType::from_syn_type(
+            TypeContext {
+                config: &self.container.attrs.ty_config,
+                generics: self.container.generics(),
+            },
+            field.ty,
+        );
 
         if let Some(t) = &ts_attrs.type_override {
             let type_params = if let Some(params) = &ts_attrs.type_params {
@@ -305,7 +311,7 @@ impl<'a> Parser<'a> {
         let relevant_type_params = self.create_relevant_type_params(type_ref_names);
 
         Decl::TsEnum(TsEnumDecl {
-            id: self.container.ident_str(),
+            id: self.container.declaration_name(),
             type_params: relevant_type_params,
             members,
             namespace: self.container.attrs.namespace,

--- a/tsify-macros/src/type_alias.rs
+++ b/tsify-macros/src/type_alias.rs
@@ -2,15 +2,24 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
-    attrs::TypeGenerationConfig, comments::extract_doc_comments, decl::TsTypeAliasDecl,
-    error_tracker::ErrorTracker, typescript::TsType,
+    attrs::TypeGenerationConfig,
+    comments::extract_doc_comments,
+    decl::TsTypeAliasDecl,
+    error_tracker::ErrorTracker,
+    typescript::{TsType, TypeContext},
 };
 
 /// Expand a `#[declare]` macro on a Rust `type = ...` expression.
 pub fn expand(item: syn::ItemType) -> syn::Result<TokenStream> {
     let errors = ErrorTracker::new();
 
-    let type_ann = TsType::from_syn_type(&TypeGenerationConfig::default(), item.ty.as_ref());
+    let type_ann = TsType::from_syn_type(
+        TypeContext {
+            config: &TypeGenerationConfig::default(),
+            generics: &item.generics,
+        },
+        item.ty.as_ref(),
+    );
 
     let decl = TsTypeAliasDecl {
         id: item.ident.to_string(),

--- a/tsify-macros/src/typescript/ts_type.rs
+++ b/tsify-macros/src/typescript/ts_type.rs
@@ -6,6 +6,27 @@ use crate::attrs::TypeGenerationConfig;
 
 use super::{NullType, TsKeywordTypeKind, TsTypeElement, TsTypeLit};
 
+/// What stays fixed for the whole of one conversion from a `syn` type.
+#[derive(Clone, Copy)]
+pub struct TypeContext<'a> {
+    pub config: &'a TypeGenerationConfig,
+    pub generics: &'a syn::Generics,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TsTypeRefSource {
+    Rust(syn::Path),
+    Synthetic,
+    TypeParam,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TsTypeRef {
+    pub name: String,
+    pub source: TsTypeRefSource,
+    pub type_params: Vec<TsType>,
+}
+
 /// A Typescript type
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TsType {
@@ -20,10 +41,7 @@ pub enum TsType {
     /// An optional type along with how a missing value is represented (i.e., as `undefined` or `null`).
     Option(Box<Self>, NullType),
     /// A reference to a type like `Foo`, `Bar<T>`, etc.
-    Ref {
-        name: String,
-        type_params: Vec<Self>,
-    },
+    Ref(TsTypeRef),
     /// A function type like `(arg0: string, arg1: number) => void`
     Fn {
         params: Vec<Self>,
@@ -96,7 +114,7 @@ impl TsType {
     }
 
     /// Convert a `syn::Type` to a `TsType`
-    pub fn from_syn_type(config: &TypeGenerationConfig, ty: &syn::Type) -> Self {
+    pub fn from_syn_type(ctx: TypeContext, ty: &syn::Type) -> Self {
         use syn::Type::*;
         use syn::{
             TypeArray, TypeBareFn, TypeGroup, TypeImplTrait, TypeParamBound, TypeParen, TypePath,
@@ -105,7 +123,7 @@ impl TsType {
 
         match ty {
             Array(TypeArray { elem, len, .. }) => {
-                let elem = Self::from_syn_type(config, elem);
+                let elem = Self::from_syn_type(ctx, elem);
                 let len = parse_len(len);
 
                 match len {
@@ -114,22 +132,20 @@ impl TsType {
                 }
             }
 
-            Slice(TypeSlice { elem, .. }) => {
-                Self::Array(Box::new(Self::from_syn_type(config, elem)))
-            }
+            Slice(TypeSlice { elem, .. }) => Self::Array(Box::new(Self::from_syn_type(ctx, elem))),
 
             Reference(TypeReference { elem, .. })
             | Paren(TypeParen { elem, .. })
-            | Group(TypeGroup { elem, .. }) => Self::from_syn_type(config, elem),
+            | Group(TypeGroup { elem, .. }) => Self::from_syn_type(ctx, elem),
 
             BareFn(TypeBareFn { inputs, output, .. }) => {
                 let params = inputs
                     .iter()
-                    .map(|arg| Self::from_syn_type(config, &arg.ty))
+                    .map(|arg| Self::from_syn_type(ctx, &arg.ty))
                     .collect();
 
                 let type_ann = if let syn::ReturnType::Type(_, ty) = output {
-                    Self::from_syn_type(config, ty)
+                    Self::from_syn_type(ctx, ty)
                 } else {
                     TsType::VOID
                 };
@@ -142,24 +158,24 @@ impl TsType {
 
             Tuple(TypeTuple { elems, .. }) => {
                 if elems.is_empty() {
-                    TsType::nullish(config)
+                    TsType::nullish(ctx.config)
                 } else {
                     let elems = elems
                         .iter()
-                        .map(|ty| Self::from_syn_type(config, ty))
+                        .map(|ty| Self::from_syn_type(ctx, ty))
                         .collect();
                     Self::Tuple(elems)
                 }
             }
 
-            Path(TypePath { path, .. }) => Self::from_path(config, path).unwrap_or(TsType::NEVER),
+            Path(TypePath { path, .. }) => Self::from_path(ctx, path).unwrap_or(TsType::NEVER),
 
             TraitObject(TypeTraitObject { bounds, .. })
             | ImplTrait(TypeImplTrait { bounds, .. }) => {
                 let elems = bounds
                     .iter()
                     .filter_map(|t| match t {
-                        TypeParamBound::Trait(t) => Self::from_path(config, &t.path),
+                        TypeParamBound::Trait(t) => Self::from_path(ctx, &t.path),
                         _ => None, // skip lifetime etc.
                     })
                     .collect();
@@ -175,16 +191,17 @@ impl TsType {
 
     /// Convert a `syn::Path` to a `TsType`. For example `core::option::Option<i32>` would be
     /// converted to `Self::Option(number)`.
-    fn from_path(config: &TypeGenerationConfig, path: &syn::Path) -> Option<Self> {
+    fn from_path(ctx: TypeContext, path: &syn::Path) -> Option<Self> {
         path.segments
             .last()
-            .map(|segment| Self::from_terminal_path_segment(config, segment))
+            .map(|segment| Self::from_terminal_path_segment(ctx, path, segment))
     }
 
     /// Convert a `syn::PathSegment` to a `TsType`. For example `Option<i32>` would be converted to
     /// `Self::Option(number)`.
     fn from_terminal_path_segment(
-        config: &TypeGenerationConfig,
+        ctx: TypeContext,
+        path: &syn::Path,
         segment: &syn::PathSegment,
     ) -> Self {
         let name = segment.ident.to_string();
@@ -218,7 +235,7 @@ impl TsType {
             syn::PathArguments::None => (vec![], None),
         };
 
-        Self::from_name(config, &name, args, output)
+        Self::from_name(ctx, path, &name, args, output)
     }
 
     pub fn with_tag_type(
@@ -299,7 +316,7 @@ impl TsType {
         f(self);
 
         match self {
-            TsType::Ref { type_params, .. } => {
+            TsType::Ref(TsTypeRef { type_params, .. }) => {
                 type_params.iter().for_each(|t| t.visit(f));
             }
             TsType::Array(elem) => elem.visit(f),
@@ -327,7 +344,7 @@ impl TsType {
         let mut set: HashSet<&String> = HashSet::new();
 
         self.visit(&mut |ty: &TsType| match ty {
-            TsType::Ref { name, .. } => {
+            TsType::Ref(TsTypeRef { name, .. }) => {
                 set.insert(name);
             }
             TsType::Override { type_params, .. } => set.extend(type_params),
@@ -348,24 +365,27 @@ impl TsType {
             TsType::Option(t, null) => {
                 TsType::Option(Box::new(t.prefix_type_refs(prefix, exceptions)), null)
             }
-            TsType::Ref { name, type_params } => {
-                if exceptions.contains(&name) {
-                    TsType::Ref {
-                        name,
-                        type_params: type_params
-                            .iter()
-                            .map(|t| t.clone().prefix_type_refs(prefix, exceptions))
-                            .collect(),
-                    }
+            TsType::Ref(TsTypeRef {
+                name,
+                source,
+                type_params,
+            }) => {
+                // The prefix changes how the reference renders, not what it refers to,
+                // so the origin is kept: a name disagreeing with its origin is #94.
+                let name = if exceptions.contains(&name) {
+                    name
                 } else {
-                    TsType::Ref {
-                        name: format!("{}{}", prefix, name),
-                        type_params: type_params
-                            .iter()
-                            .map(|t| t.clone().prefix_type_refs(prefix, exceptions))
-                            .collect(),
-                    }
-                }
+                    format!("{}{}", prefix, name)
+                };
+
+                TsType::Ref(TsTypeRef {
+                    name,
+                    source,
+                    type_params: type_params
+                        .iter()
+                        .map(|t| t.clone().prefix_type_refs(prefix, exceptions))
+                        .collect(),
+                })
             }
             TsType::Fn { params, type_ann } => TsType::Fn {
                 params: params
@@ -400,15 +420,16 @@ impl TsType {
         }
     }
 
-    pub fn type_refs(&self, type_refs: &mut Vec<(String, Vec<TsType>)>) {
+    pub fn type_refs(&self, type_refs: &mut Vec<TsTypeRef>) {
         match self {
             TsType::Array(t) | TsType::Option(t, _) => t.type_refs(type_refs),
             TsType::Tuple(tv) | TsType::Union(tv) | TsType::Intersection(tv) => {
                 tv.iter().for_each(|t| t.type_refs(type_refs))
             }
-            TsType::Ref { name, type_params } => {
-                type_refs.push((name.clone(), type_params.clone()));
-                type_params
+            TsType::Ref(type_ref) => {
+                type_refs.push(type_ref.clone());
+                type_ref
+                    .type_params
                     .iter()
                     .for_each(|t| t.clone().type_refs(type_refs));
             }

--- a/tsify-macros/src/typescript/ts_type.test.rs
+++ b/tsify-macros/src/typescript/ts_type.test.rs
@@ -1,12 +1,13 @@
 use crate::attrs::TypeGenerationConfig;
 
-use super::TsType;
+use super::{TsType, TsTypeRef, TsTypeRefSource, TypeContext};
 
 macro_rules! assert_ts {
         ($config:expr, $( $t:ty )|* , $expected:expr) => {
           $({
             let ty: syn::Type = syn::parse_quote!($t);
-            let ts_type = TsType::from_syn_type(&$config, &ty);
+            let ctx = TypeContext { config: &$config, generics: &syn::Generics::default() };
+            let ts_type = TsType::from_syn_type(ctx, &ty);
             assert_eq!(ts_type.to_string(), $expected);
           })*
         };
@@ -75,4 +76,47 @@ fn test_basic_types() {
         RangeInclusive<usize>,
         "{ start: number; end: number }"
     );
+}
+
+#[test]
+fn test_rust_type_ref_keeps_path() {
+    let config = TypeGenerationConfig::default();
+    let ty: syn::Type = syn::parse_quote!(a::Config<String>);
+    let expected_path: syn::Path = syn::parse_quote!(a::Config<String>);
+
+    let ts_type = TsType::from_syn_type(
+        TypeContext {
+            config: &config,
+            generics: &syn::Generics::default(),
+        },
+        &ty,
+    );
+
+    assert!(matches!(
+        ts_type,
+        TsType::Ref(TsTypeRef {
+            name,
+            source: TsTypeRefSource::Rust(path),
+            ..
+        }) if name == "Config" && path == expected_path
+    ));
+
+    let ty: syn::Type = syn::parse_quote!(T);
+    let generics: syn::Generics = syn::parse_quote!(<T>);
+    let ts_type = TsType::from_syn_type(
+        TypeContext {
+            config: &config,
+            generics: &generics,
+        },
+        &ty,
+    );
+
+    assert!(matches!(
+        ts_type,
+        TsType::Ref(TsTypeRef {
+            name,
+            source: TsTypeRefSource::TypeParam,
+            ..
+        }) if name == "T"
+    ));
 }

--- a/tsify-macros/src/typescript/ts_type_display.rs
+++ b/tsify-macros/src/typescript/ts_type_display.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use super::TsType;
+use super::{TsType, TsTypeRef};
 
 impl Display for TsType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -31,7 +31,9 @@ impl Display for TsType {
                 write!(f, "[{elems}]")
             }
 
-            TsType::Ref { name, type_params } => {
+            TsType::Ref(TsTypeRef {
+                name, type_params, ..
+            }) => {
                 let params = type_params
                     .iter()
                     .map(|param| param.to_string())

--- a/tsify-macros/src/typescript/ts_type_from_name.rs
+++ b/tsify-macros/src/typescript/ts_type_from_name.rs
@@ -1,6 +1,4 @@
-use crate::attrs::TypeGenerationConfig;
-
-use super::{NullType, TsType, TsTypeElement, TsTypeLit};
+use super::{NullType, TsType, TsTypeElement, TsTypeLit, TsTypeRef, TsTypeRefSource, TypeContext};
 
 /// Create a type literal with the given key-value pairs.
 /// E.g. `type_lit! { key1: type1; key2: type2 }` will create a type literal with two members
@@ -23,7 +21,8 @@ macro_rules! type_lit {
 impl TsType {
     /// Create a `TsType` from a stringified Rust identifier.
     pub fn from_name(
-        config: &TypeGenerationConfig,
+        ctx: TypeContext,
+        path: &syn::Path,
         ident: &str,
         args: Vec<&syn::Type>,
         fn_output: Option<&syn::Type>,
@@ -32,7 +31,7 @@ impl TsType {
             "u8" | "u16" | "u32" | "i8" | "i16" | "i32" | "f64" | "f32" => Self::NUMBER,
 
             "usize" | "isize" | "u64" | "i64" => {
-                if cfg!(feature = "js") && config.large_number_types_as_bigints {
+                if cfg!(feature = "js") && ctx.config.large_number_types_as_bigints {
                     Self::BIGINT
                 } else {
                     Self::NUMBER
@@ -52,54 +51,59 @@ impl TsType {
             "bool" => Self::BOOLEAN,
 
             "Box" | "Cow" | "Rc" | "Arc" | "Cell" | "RefCell" if args.len() == 1 => {
-                Self::from_syn_type(config, args[0])
+                Self::from_syn_type(ctx, args[0])
             }
 
             "Vec" | "VecDeque" | "LinkedList" if args.len() == 1 => {
-                let elem = Self::from_syn_type(config, args[0]);
+                let elem = Self::from_syn_type(ctx, args[0]);
                 Self::Array(Box::new(elem))
             }
 
             "HashMap" | "BTreeMap" if args.len() == 2 => {
                 let type_params = args
                     .iter()
-                    .map(|arg| Self::from_syn_type(config, arg))
+                    .map(|arg| Self::from_syn_type(ctx, arg))
                     .collect();
 
-                let name = if cfg!(feature = "js") && !config.hashmap_as_object {
+                let name = if cfg!(feature = "js") && !ctx.config.hashmap_as_object {
                     "Map"
                 } else {
                     "Record"
                 }
                 .to_string();
 
-                Self::Ref { name, type_params }
+                Self::Ref(TsTypeRef {
+                    name,
+                    source: TsTypeRefSource::Synthetic,
+                    type_params,
+                })
             }
 
             "HashSet" | "BTreeSet" if args.len() == 1 => {
-                let elem = Self::from_syn_type(config, args[0]);
+                let elem = Self::from_syn_type(ctx, args[0]);
                 Self::Array(Box::new(elem))
             }
 
             "Option" if args.len() == 1 => Self::Option(
-                Box::new(Self::from_syn_type(config, args[0])),
-                NullType::new(config),
+                Box::new(Self::from_syn_type(ctx, args[0])),
+                NullType::new(ctx.config),
             ),
 
             "ByteBuf" => {
                 if cfg!(feature = "js") {
-                    Self::Ref {
+                    Self::Ref(TsTypeRef {
                         name: String::from("Uint8Array"),
+                        source: TsTypeRefSource::Synthetic,
                         type_params: vec![],
-                    }
+                    })
                 } else {
                     Self::Array(Box::new(Self::NUMBER))
                 }
             }
 
             "Result" if args.len() == 2 => {
-                let arg0 = Self::from_syn_type(config, args[0]);
-                let arg1 = Self::from_syn_type(config, args[1]);
+                let arg0 = Self::from_syn_type(ctx, args[0]);
+                let arg1 = Self::from_syn_type(ctx, args[1]);
 
                 let ok = type_lit! { Ok: arg0 };
                 let err = type_lit! { Err: arg1 };
@@ -120,7 +124,7 @@ impl TsType {
             // Treat as std::ops::Range or std::ops::RangeInclusive only when there is exactly one type parameter.
             // Otherwise, consider it a user-defined type and do not perform any conversion.
             "Range" | "RangeInclusive" if args.len() == 1 => {
-                let start = Self::from_syn_type(config, args[0]);
+                let start = Self::from_syn_type(ctx, args[0]);
                 let end = start.clone();
 
                 type_lit! {
@@ -132,10 +136,10 @@ impl TsType {
             "Fn" | "FnOnce" | "FnMut" => {
                 let params = args
                     .into_iter()
-                    .map(|ty| Self::from_syn_type(config, ty))
+                    .map(|ty| Self::from_syn_type(ctx, ty))
                     .collect();
                 let type_ann = fn_output
-                    .map(|ty| Self::from_syn_type(config, ty))
+                    .map(|ty| Self::from_syn_type(ctx, ty))
                     .unwrap_or_else(|| TsType::VOID);
 
                 Self::Fn {
@@ -146,12 +150,30 @@ impl TsType {
             _ => {
                 let type_params = args
                     .into_iter()
-                    .map(|ty| Self::from_syn_type(config, ty))
+                    .map(|ty| Self::from_syn_type(ctx, ty))
                     .collect();
-                Self::Ref {
-                    name: config.format_name(ident.to_string()),
+                let is_type_param = ctx
+                    .generics
+                    .type_params()
+                    .any(|param| path.get_ident() == Some(&param.ident));
+
+                // A type parameter has no declaration for the affix to have renamed to
+                // match, so affixing it invents a reference to a type that does not
+                // exist, and hides the parameter from create_relevant_type_params.
+                let (name, source) = if is_type_param {
+                    (ident.to_string(), TsTypeRefSource::TypeParam)
+                } else {
+                    (
+                        ctx.config.format_name(ident.to_string()),
+                        TsTypeRefSource::Rust(path.clone()),
+                    )
+                };
+
+                Self::Ref(TsTypeRef {
+                    name,
+                    source,
                     type_params,
-                }
+                })
             }
         }
     }


### PR DESCRIPTION
Closes #70. Also fixes two bugs older than 0.5.7, including the tag-literal half of #94 — see below.

Container-level `#[serde(rename)]` stopped affecting the TypeScript name in `3e81856`, which fixed #43 by making declarations and references agree on the Rust ident. That left no way to rename a type at all, and it blocks the 0.4 → 0.5 upgrade for anyone with two same-named types in different modules — three people have run into it.

`#[tsify(rename = "...")]` names the generated declaration:

```rust
#[derive(Tsify, Serialize, Deserialize)]
#[tsify(rename = "PublicConfig")]
pub struct Config { pub x: i32 }

#[wasm_bindgen]
pub fn take(c: Ts<Config>) -> Ts<Config> { c }
```

```ts
export interface PublicConfig {
    x: number;
}

export function take(c: PublicConfig): PublicConfig;
```

**This renames the declaration and nothing else.** References from other types still emit the Rust ident, so other tsify types that refer to a renamed type need `#[tsify(type = "PublicConfig")]` at each reference site. @katherine-hough confirmed on #70 that this is already how they work and that it unblocks them.

## Why `rename` rather than a narrower name

This spent a while as `declaration_name`, on the reasoning that references *can't* follow, since a derive sees one type at a time. They can: a marker macro sharing the type's identifier rides Rust's own name resolution, generics included, on stable and with no upstream changes — verified through to the emitted `.d.ts`. #103 has the mechanism.

So the limitation here is where the work stopped rather than where the design ends, and naming the attribute after it is what would have made it permanent.

**That is not a promise that references will start following.** Doing it would be partial by construction — `use X as Y` carries the marker, `type Y = X` does not, and foreign types and manual `impl Tsify` have no marker at all — and switching it on could change `.d.ts` that is valid today, or stop a crate compiling outright where a user macro already shares a type's name. #103 collects what a design would have to settle; if it lands it will be opt-in.

## Knowing what a name refers to

Deciding what a name may be renamed to means knowing what the name refers to, so a reference now records where it came from: a Rust path, a synthetic name like `Map`, or a type parameter. Two bugs fall out of having that distinction available. Both predate 0.5.7 — the affix dates to `71de564`.

### A type parameter is not a declaration

`#[tsify(type_prefix = "Ts")]` on a generic type emitted TypeScript that does not type-check:

```ts
export interface TsPrefixedGeneric {   // <T> is gone
    x: TsT;                            // TsT is never declared
}
```

A type parameter has no declaration for the affix to rename — `TsT` is a reference to a type that does not exist. Affixing it also stops `create_relevant_type_params` recognizing the parameter, since that compares against the raw ident, which is how `<T>` disappears from the declaration. Under `namespace` the same mismatch reaches further, hoisting the unrecognized parameter into a `type __PrefixedTsT = TsT;` alias of its own.

Worth noting against #94's description of the attribute as crate-wide: applying it to every type did not rescue this one, because a type parameter has no declaration to carry a matching affix. Until now there was no correct way to use `type_prefix` or `type_suffix` on a generic type at all. With the affix confined to names that refer to declarations, crate-wide application resolves generic types the same way it already resolved the rest — a test pins that.

### A tag literal is not a type name

The `{ kind: "..." }` value of an internally-tagged type is written by serde, and serde knows nothing about the affix:

```rust
#[derive(Tsify, Serialize, Deserialize)]
#[serde(tag = "kind")]
#[tsify(type_prefix = "A")]
struct Config { x: i32 }
```

```ts
export interface AConfig {
    kind: "AConfig";   // serde writes "Config"
    x: number;
}
```

This one type-checks, so consumers narrowing on `kind === "AConfig"` compiled fine and never matched at runtime. Every other wire-facing name — variant tags, field keys — already came straight from serde; only the container name had the affix applied on top. A test now pins the declaration against what `serde_json` actually writes, so the two cannot drift apart again unnoticed.

`#[serde(rename)]` still reaches the tag, since that one does change the wire.

### What is still open

- Partial application of `type_prefix`/`type_suffix` still emits references to names that don't exist — the other half of #94, unchanged here.
- A type parameter named after a type tsify handles specially — `String`, `Duration`, `Path`, `Map`, `Record`, `Uint8Array` — is still swallowed by the arm that handles that type, so `struct S<String> { x: String }` loses `<String>`. The provenance check sits in the fallthrough arm, which those never reach. No affix is needed to reproduce it.

## Two refactors

Neither changes behavior; the e2e `.d.ts` outputs are byte-identical.

- **`TypeContext`** bundles the generation config and the generics. Both are fixed for the whole of one conversion and were threaded as separate parameters through nineteen call sites, only two of which construct them.
- **`TsTypeRef`** names the three fields of a type reference. `type_refs` had been collecting them into a bare `(String, TsTypeRefSource, Vec<TsType>)` for its single consumer to take apart and rebuild into the same three fields.

## Tests

No affix test used a generic type or a tag, and no generics test used an affix, so nothing covered either combination. Added, along with the cases `rename` reaches that the first round of tests did not:

- `rename` through `#[wasm_bindgen(typescript_type = ...)]`, as an expansion snapshot — previously only checked by hand.
- `rename` with `namespace` and generics; with newtype, unit, transparent and container `type` declarations; and with internally, adjacently and untagged enums.
- The affix against type parameters nested in `Vec`, `HashMap`, `Option`, tuples, `Box`, function types, and inside a namespace — including a type parameter and a real type in the same struct, where only the real one takes the affix.
- The compile-fail cases are now separate modules checked by diagnostic *and* source position, rather than by counting occurrences in one shared fixture, so one case can no longer mask another. Empty string, leading digit, non-string, missing value, duplicates across separate `#[tsify]` attributes, and all four orderings of `rename` with an affix.

## Details worth reviewing

- **`rename` with `type_prefix`/`type_suffix` is rejected** rather than silently composed. Validation happens after parsing, so it fails in either attribute order.
- **The rename reaches `#[wasm_bindgen(typescript_type = ...)]` for free**, since `wasm_bindgen.rs` derives that from `decl.id()`. The snapshot encodes the name one character at a time, as wasm-bindgen's `describe` does; the length `inform` in front of it is what changes if the rename stops arriving.
- **`rename` accepts TypeScript reserved words.** `is_ts_identifier` checks the character shape only, so `rename = "class"` compiles. `pub struct string` is legal Rust, so this gap is not new with `rename`; a word list needs checking against `tsc` one word at a time, since `type` is a legal type name.
