### PR TITLE
Scope the PR CI token

### DIFF
--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -5,8 +5,8 @@ name: Check wasm-bindgen changes
 # Since all PRs that affect tsify's macro output should update their own tests, this should only detect
 # changes in other rust crates.
 #
-# If this job fails (e.g. the expansion itself errors out), it opens a tracking
-# issue so the failure is not silently lost in the Actions tab.
+# If a run does not reach a recognized healthy state, it opens a tracking issue
+# so the breakage is not silently lost in the Actions tab.
 #
 # Split into three jobs so the token that can write to the repository is never
 # in scope while dependencies are resolved and arbitrary build scripts run:
@@ -146,9 +146,9 @@ jobs:
     track:
         name: Track failures
         needs: [expand, open-pr]
-        # `always()` so this still runs when `open-pr` was skipped for having
-        # nothing to do, which is the ordinary outcome.
-        if: always()
+        # Not `always()`: a cancelled run says nothing about the snapshots, and
+        # under the condition below it would file a report anyway.
+        if: ${{ !cancelled() }}
         runs-on: ubuntu-latest
         permissions:
             issues: write
@@ -159,27 +159,25 @@ jobs:
               with:
                   persist-credentials: false
 
-            # Listing the two good outcomes rather than excluding failure:
-            # `result` is also `cancelled`, which is not a success.
-            - name: Close failure tracking issue on success
-              if: needs.expand.result == 'success' && (needs.open-pr.result == 'success' || needs.open-pr.result == 'skipped')
+            # `open-pr` being skipped is not by itself evidence of health — a
+            # job output the runner drops produces it too. Only the two pairs
+            # below are healthy; every other state files the issue, so an
+            # unrecognized one cannot pass as success.
+            - name: Reconcile the tracking issue
               uses: ./.github/actions/track-failure-issue
               with:
-                  mode: close
-                  title: ${{ env.ISSUE_TITLE }}
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Notify on failure
-              if: needs.expand.result == 'failure' || needs.open-pr.result == 'failure'
-              uses: ./.github/actions/track-failure-issue
-              with:
-                  mode: notify
+                  mode: >-
+                      ${{ needs.expand.result == 'success' &&
+                      ((needs.expand.outputs.changed == 'false' && needs.open-pr.result == 'skipped') ||
+                      (needs.expand.outputs.changed == 'true' && needs.open-pr.result == 'success'))
+                      && 'close' || 'notify' }}
                   title: ${{ env.ISSUE_TITLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   body: |
-                      The scheduled expand check failed.
+                      The scheduled expand check did not reach a healthy state.
 
                       Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                       Resolved wasm-bindgen: ${{ needs.expand.outputs.wasm-bindgen-version || 'unknown' }}
+                      State: expand=${{ needs.expand.result }} changed=${{ needs.expand.outputs.changed || 'unset' }} open-pr=${{ needs.open-pr.result }}
 
                       Likely causes: a new wasm-bindgen release whose changed macro output breaks expansion, or a toolchain change that altered `-Zunpretty=expanded` behavior. See CONTRIBUTING.md for how to regenerate the snapshots.

--- a/.github/workflows/check-wasmbindgen-changes.yml
+++ b/.github/workflows/check-wasmbindgen-changes.yml
@@ -159,8 +159,10 @@ jobs:
               with:
                   persist-credentials: false
 
+            # Listing the two good outcomes rather than excluding failure:
+            # `result` is also `cancelled`, which is not a success.
             - name: Close failure tracking issue on success
-              if: needs.expand.result == 'success' && needs.open-pr.result != 'failure'
+              if: needs.expand.result == 'success' && (needs.open-pr.result == 'success' || needs.open-pr.result == 'skipped')
               uses: ./.github/actions/track-failure-issue
               with:
                   mode: close

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,8 +6,7 @@ on:
     pull_request:
         branches: ["*"]
 
-# Every job here builds and runs tests, which executes dependency build
-# scripts. None of them write to the repository.
+# Build and test only — and dependency build scripts run arbitrary code here.
 permissions:
     contents: read
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -6,6 +6,11 @@ on:
     pull_request:
         branches: ["*"]
 
+# Every job here builds and runs tests, which executes dependency build
+# scripts. None of them write to the repository.
+permissions:
+    contents: read
+
 jobs:
     build:
         name: Build
@@ -14,6 +19,8 @@ jobs:
         steps:
             - name: Checkout sources
               uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
 
             - name: Install toolchain
               run: rustup toolchain install stable --profile minimal --override
@@ -30,6 +37,8 @@ jobs:
         steps:
             - name: Checkout sources
               uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
 
             # This job compares the expansion snapshots that the nightly
             # workflow regenerates, so both must use the same cargo-expand.
@@ -45,6 +54,8 @@ jobs:
         steps:
             - name: Checkout sources
               uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
 
             - name: Install toolchain
               run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --override


### PR DESCRIPTION
Follow-up to #96, which took the write token away from the nightly build but left the same exposure in the workflow that runs on **every pull request**.

`on-pull-request.yml` declared no `permissions`, so it inherited the repository default — `write` — and its three checkouts left those credentials on disk. All three jobs build the workspace and run the test suite, so dependency build scripts and test code ran with a repository-writable token in reach.

Measured before the change:

```
$ gh api repos/madonoharu/tsify/actions/permissions/workflow
{"default_workflow_permissions": "write", "can_approve_pull_request_reviews": true}
```

## Changes

- `permissions: { contents: read }` at the workflow level. These jobs only build and test.
- `persist-credentials: false` on all three checkouts. Nothing here pushes.
- Repository default workflow permissions set to `read`. All three workflows declare their own permissions, so nothing was relying on the default.

`can_approve_pull_request_reviews` stays `true`. I turned it off first, and that broke the nightly: despite the field name, the one setting also governs *creating* pull requests, and `open-pr` failed with `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`. The scoping that actually limits reach here is per-job — only `open-pr` holds `pull-requests: write`, and it builds nothing.

## Also: the nightly tracking issue could close itself on a breakage

`track` decided success from job results alone, treating anything that was not `failure` as success — so a cancelled run counted as one. Listing the good outcomes fixes that, but not the deeper problem: **`skipped` was standing in for "nothing drifted"**, and that is an inference, not a fact.

`open-pr` is skipped whenever its `if` is false, and `needs.expand.outputs.changed` is empty — not `'true'` — whenever the runner drops that output. It drops outputs that are empty or that match a masked secret, with a warning and without failing the job ([`JobExtension.cs`](https://github.com/actions/runner/blob/258d6c857db3519913f7deb6004b60172f8043ae/src/Runner.Worker/JobExtension.cs#L804-L814)). Real drift could therefore end with `expand` green, `open-pr` skipped, and the tracking issue closed.

`track` now reads the value that caused the skip, and accepts only the two states that mean healthy:

- `changed == 'false'` and `open-pr` skipped — nothing to do
- `changed == 'true'` and `open-pr` succeeded — the update PR is open

Every other state files the issue instead of falling through silently, which is what an unrecognized one used to do. Close and notify became one step: they were answering the same question through two conditions that had to be kept in agreement. The issue body now carries the observed state, so an unexpected combination is diagnosable from the issue itself.

`always()` becomes `!cancelled()` — cancelling a run says nothing about the snapshots, and under the new condition it would otherwise file a report. This is also the documented recommendation: `always()` is called out as something to [avoid for any task that could suffer from a critical failure, "for example: getting sources"](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always), which is the first thing this job does.

## Verified

Both nightly paths were run end to end on throwaway branches, with a tracking issue open beforehand so the close had something to act on. Branches, the bot PR, and the issues have been cleaned up.

| | `expand` | `open-pr` | `track` | tracking issue |
|---|---|---|---|---|
| snapshots fresh | success | skipped | success | closed |
| snapshots staled | success | success (PR opened) | success | closed |

The first row is the one that mattered: `track` still runs under `!cancelled()` when `open-pr` is skipped, which is the ordinary nightly outcome and would have taken the whole mechanism down if it did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Geua8faXp7HPKTKVJqfBeQ
