### PR TITLE
Drop a unit let-binding clippy 1.98 rejects

### DIFF
--- a/tests/ts.rs
+++ b/tests/ts.rs
@@ -160,7 +160,7 @@ impl Serialize for CantBeSerialized {
 fn test_data_that_cant_be_serialized_throws_an_appropriate_error() {
     let val = CantBeSerialized { value: 42 }.into_ts().unwrap();
 
-    let _ = do_not_serialize(val).unwrap();
+    do_not_serialize(val).unwrap();
 }
 
 // No point testing Vec<Ts<CantBeSerialized>> here, since you call the same


### PR DESCRIPTION
`clippy::let_unit_value` fires on `let _ = do_not_serialize(val).unwrap()` in `tests/ts.rs`, because the binding's type is `()`. The lint is on by default, so `cargo clippy --all-targets -- -D warnings` — what the `Lint` job runs — fails.

**CI is green only because the runners have not picked up 1.98 yet.** Measured on `main` with a local toolchain that moved from 1.97.1 to 1.98.0 during the day:

```
$ git switch --detach origin/main && cargo clippy --all-targets -- -D warnings
error: this let-binding has unit value
   --> tests/ts.rs:163:5
error: could not compile `tsify` (test "ts") due to 1 previous error
```

One occurrence; both feature sets are clean with it removed.

Worth noting for the CI design: neither scheduled workflow would have caught this. `latest-deps` runs the test suite against the newest dependencies but no clippy, and the nightly expand check only compares macro output. Both resolve the toolchain fresh, so a lint that arrives with a rustc release lands in PR CI first — on whichever PR happens to be open when the runners update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Geua8faXp7HPKTKVJqfBeQ