### PR TITLE
Release 0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tsify Changelog
 
+## v0.5.8
+
+- Added `#[tsify(rename = "...")]`, which renames the generated TypeScript declaration and nothing else — references from other types still emit the Rust ident, so point them at the new name with `#[tsify(type = "...")]` at each reference site. Cannot be combined with `type_prefix` or `type_suffix`. Resolves #70, which had been blocking the 0.4 → 0.5 upgrade for anyone with two same-named types in different modules
+- **`type_prefix` and `type_suffix` no longer rename type parameters.** A type parameter has no declaration for the affix to rename, so `#[tsify(type_prefix = "Ts")] struct Wrapper<T> { x: T }` declared `export interface TsWrapper { x: TsT; }` — the parameter dropped, and `TsT` never declared anywhere. It now declares `export interface TsWrapper<T> { x: T; }`. **If you use either attribute on a generic type, its `.d.ts` changes.** There was no correct way to use the affix on a generic type before this, so nothing that type-checked without `skipLibCheck` is affected
+- **`type_prefix` and `type_suffix` no longer reach the tag literal of an internally-tagged type.** That value comes from serde, which was never told about the affix, so `#[serde(tag = "kind")] #[tsify(type_prefix = "A")] struct Config` declared `kind: "AConfig"` where serde has always serialized `"Config"`. It now declares `kind: "Config"`. **If you narrowed on the old literal, that code compiled and never matched at runtime; it is now a compile error.** Applying either attribute to only some of your types still emits references to names that were never declared — that half of #94 is still open
+
 ## v0.5.7
 
 - Added `Ts<T>`, a wrapper for `#[wasm_bindgen]` parameters and return types. `#[tsify(from_wasm_abi)]` deserializes at the ABI boundary, which cannot report failure, so bad input from JavaScript ends in `wasm_bindgen::throw_str` — a catchable JS exception that skips destructors, leaking a little on every failure until the instance dies. `Ts<T>` keeps the boundary infallible and moves the conversion into the function body, where it is an ordinary `Result`. Addresses #65, #47 and #86. @cormacrelf contributed #71

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 authors = [
   "Madono Haru <madonoharu@gmail.com>",
@@ -14,7 +14,7 @@ keywords = ["wasm", "wasm-bindgen", "typescript"]
 categories = ["wasm"]
 
 [dependencies]
-tsify-macros = { path = "tsify-macros", version = "0.5.7" }
+tsify-macros = { path = "tsify-macros", version = "0.5.8" }
 wasm-bindgen = { version = "0.2.104", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Click to show Cargo.toml.
 
 ```toml
 [dependencies]
-tsify = "0.5.7"
+tsify = "0.5.8"
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = { version = "0.2" }
 ```

--- a/tsify-macros/Cargo.toml
+++ b/tsify-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsify-macros"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 authors = [
     "Madono Haru <madonoharu@gmail.com>",


### PR DESCRIPTION
Version bump only — the code is already on `main` from #98.

Both crates move together, and the root's floor on `tsify-macros` moves with them (`version = "0.5.8"`, not `^0.5.7`), so a user updating the root cannot resolve an older macro crate against it. That floor is what 0.5.7 existed to fix; keeping it in step is the point of the release runbook.

## What ships

- `#[tsify(rename = "...")]`, which renames the generated declaration. Resolves #70, an upgrade blocker for 0.4 → 0.5 since container-level `#[serde(rename)]` stopped affecting the TypeScript name.
- Two affix bugs older than 0.5.7: `type_prefix`/`type_suffix` no longer rename type parameters, and no longer reach the tag literal of an internally-tagged type. The second is the first half of #94.

## Generated `.d.ts` changes for affix users

Only for crates using `type_prefix` or `type_suffix`, and only where the output was already wrong:

- A generic type declared `export interface TsWrapper { x: TsT; }` — parameter dropped, `TsT` never declared. It now declares `export interface TsWrapper<T> { x: T; }`.
- An internally-tagged type declared `kind: "AConfig"` where serde has always serialized `"Config"`. Narrowing on the old literal compiled and never matched at runtime; it is now a compile error.

The Rust API is unchanged — `src/` is untouched by #98 — so this stays a patch release under Cargo's semver. The CHANGELOG carries the before and after for each case.

## Verified locally

`./test.sh` (the same script the Test job runs) exits 0: 62 test binaries, and all seven e2e `.d.ts` files identical to their references. `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets --all-features -- -D warnings`, and `cargo test --doc` are clean.

Publishing follows the runbook: macros first, wait for the index, dry-run the root against the registry version, downstream smoke, then the root and the tag.
