### PR TITLE
Name a generic type after its type arguments across the wasm ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # tsify Changelog
 
+## Unreleased
+
+- **Generic types keep their type arguments in the signatures wasm-bindgen functions.** Resolves #76
+- **A type argument now needs a TypeScript name of its own**, the new `tsify::TsName` trait. `#[derive(Tsify)]` writes the impl, and tsify provides one for each built-in the derive already declares. **Instantiating a generic tsify type with a type that has neither is now a compile error** where it crosses the ABI, fixed by one `tsify::ts_name!` line. `DECL` is unaffected
+
 ## v0.5.8
 
 - Added `#[tsify(rename = "...")]`, which renames the generated TypeScript declaration and nothing else — references from other types still emit the Rust ident, so point them at the new name with `#[tsify(type = "...")]` at each reference site. Cannot be combined with `type_prefix` or `type_suffix`. Resolves #70, which had been blocking the 0.4 → 0.5 upgrade for anyone with two same-named types in different modules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,10 @@ mod ts;
 pub use ts::Ts;
 mod error;
 pub use error::Error;
+#[cfg(feature = "wasm-bindgen")]
+mod name;
+#[cfg(feature = "wasm-bindgen")]
+pub use name::{inform_char, TsName};
 
 #[cfg(all(feature = "json", not(feature = "js")))]
 pub use gloo_utils::format::JsValueSerdeExt;

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,344 @@
+use std::borrow::Cow;
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use wasm_bindgen::describe::{inform, NAMED_EXTERNREF, VECTOR};
+
+/// The TypeScript name a type goes by inside a `#[wasm_bindgen]` signature.
+///
+/// wasm-bindgen does not read the `typescript_custom_section` when it writes a
+/// signature into the `.d.ts`. It learns the type from a *descriptor*: a stream
+/// of `u32`s the compiled module informs at build time, which for a named type
+/// is `NAMED_EXTERNREF`, a character count, and then one `u32` per character.
+/// A `#[wasm_bindgen] extern` type carries one fixed name for all of its uses,
+/// so on its own it can only ever describe `Response` — never
+/// `Response<UserInfo>`, which is what the declaration in the custom section
+/// actually has to be applied to.
+///
+/// This trait rebuilds the name once per monomorphization instead: the derive
+/// unrolls the characters of the type's own declared name, and every type
+/// argument defers to its own `TsName` impl. So `Response<UserInfo>` describes
+/// itself under exactly that name, and nesting (`Response<Vec<UserInfo>>`)
+/// composes.
+///
+/// Every character has to reach the descriptor as a compile-time constant.
+/// wasm-bindgen interprets the descriptor with a small interpreter that mirrors
+/// linear memory but never loads the module's data segments, so walking the
+/// bytes of a `&'static str` at describe time would inform a run of NULs. That
+/// is why the name is a sequence of [`inform_char`] calls and a `const` length
+/// rather than a `&str`.
+///
+/// # Implementing by hand
+///
+/// `#[derive(Tsify)]` writes this impl for you. If you implement [`Tsify`] by
+/// hand, write it with [`ts_name!`]:
+///
+/// ```
+/// struct Rgb(u8, u8, u8);
+///
+/// tsify::ts_name!(Rgb => 'R', 'g', 'b');
+/// ```
+///
+/// [`Tsify`]: crate::Tsify
+/// [`ts_name!`]: crate::ts_name
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` has no TypeScript name",
+    label = "used here as a type argument of a type that crosses the wasm ABI",
+    note = "a type argument needs a name of its own for the generic type to be named after it",
+    note = "derive `Tsify` for `{Self}`, or name it by hand with `tsify::ts_name!({Self} => 'N', 'a', 'm', 'e');`"
+)]
+pub trait TsName {
+    /// The number of `char`s that [`describe_name`](TsName::describe_name)
+    /// informs.
+    const NAME_LEN: u32;
+
+    /// Informs the name one `char` at a time, in order.
+    fn describe_name();
+
+    /// Informs the whole `NAMED_EXTERNREF` descriptor for this name.
+    #[inline]
+    fn describe_named_externref() {
+        inform(NAMED_EXTERNREF);
+        inform(Self::NAME_LEN);
+        Self::describe_name();
+    }
+
+    /// Informs the descriptor for a vector of this name.
+    #[inline]
+    fn describe_named_externref_vector() {
+        inform(VECTOR);
+        Self::describe_named_externref();
+    }
+}
+
+/// Informs one `char` of a type name, for use inside
+/// [`TsName::describe_name`].
+///
+/// Only pass a literal, or defer to another impl's `describe_name`: a character
+/// loaded from memory at describe time reaches wasm-bindgen as `\0`.
+#[inline]
+pub fn inform_char(c: char) {
+    inform(c as u32);
+}
+
+/// Implements [`TsName`] for one or more types under a fixed name, spelled one
+/// `char` at a time.
+///
+/// ```
+/// struct Rgb(u8, u8, u8);
+/// struct Rgba(u8, u8, u8, u8);
+///
+/// tsify::ts_name!(Rgb => 'R', 'g', 'b');
+/// tsify::ts_name!(Rgba => 'R', 'g', 'b', 'a');
+/// ```
+///
+/// The name is a `char` list rather than a string literal because every
+/// character has to reach wasm-bindgen's descriptor as a compile-time constant.
+/// See [`TsName`].
+#[macro_export]
+macro_rules! ts_name {
+    ($($ty:ty),+ $(,)? => $($ch:literal),+ $(,)?) => {
+        // The name is carried along as one token tree so that it can be
+        // repeated per type: a repetition cannot mix two metavariables that
+        // repeat a different number of times.
+        $crate::ts_name!(@each [$($ch),+] $($ty),+);
+    };
+
+    (@each $name:tt $($ty:ty),+) => {
+        $($crate::ts_name!(@one $ty, $name);)+
+    };
+
+    (@one $ty:ty, [$($ch:literal),+]) => {
+        impl $crate::TsName for $ty {
+            const NAME_LEN: u32 = [$($ch),+].len() as u32;
+
+            #[inline]
+            fn describe_name() {
+                $($crate::inform_char($ch);)+
+            }
+        }
+    };
+}
+
+ts_name!(
+    u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64
+    => 'n', 'u', 'm', 'b', 'e', 'r'
+);
+
+// `u128`/`i128` follow the same rule the declaration does: they are only a JS
+// number when going through JSON, which has already narrowed them.
+#[cfg(feature = "js")]
+ts_name!(u128, i128 => 'b', 'i', 'g', 'i', 'n', 't');
+#[cfg(not(feature = "js"))]
+ts_name!(u128, i128 => 'n', 'u', 'm', 'b', 'e', 'r');
+
+ts_name!(String, str, char, Path, PathBuf => 's', 't', 'r', 'i', 'n', 'g');
+ts_name!(bool => 'b', 'o', 'o', 'l', 'e', 'a', 'n');
+
+/// Wrappers serde sees through, so TypeScript does too.
+macro_rules! ts_name_transparent {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<T: TsName + ?Sized> TsName for $ty {
+                const NAME_LEN: u32 = <T as TsName>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    <T as TsName>::describe_name();
+                }
+            }
+        )+
+    };
+}
+
+ts_name_transparent!(&T, &mut T, Box<T>, Rc<T>, Arc<T>);
+
+macro_rules! ts_name_transparent_sized {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<T: TsName> TsName for $ty {
+                const NAME_LEN: u32 = <T as TsName>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    <T as TsName>::describe_name();
+                }
+            }
+        )+
+    };
+}
+
+ts_name_transparent_sized!(Cell<T>, RefCell<T>);
+
+impl<T: TsName + ToOwned + ?Sized> TsName for Cow<'_, T> {
+    const NAME_LEN: u32 = <T as TsName>::NAME_LEN;
+
+    #[inline]
+    fn describe_name() {
+        <T as TsName>::describe_name();
+    }
+}
+
+/// Sequences, as `T[]`.
+///
+/// The element has to be parenthesized when it is a union, which is why
+/// [`Option`] below carries its own parentheses.
+macro_rules! ts_name_array {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<T: TsName> TsName for $ty {
+                const NAME_LEN: u32 = <T as TsName>::NAME_LEN + 2;
+
+                #[inline]
+                fn describe_name() {
+                    <T as TsName>::describe_name();
+                    inform_char('[');
+                    inform_char(']');
+                }
+            }
+        )+
+    };
+}
+
+ts_name_array!(Vec<T>, VecDeque<T>, LinkedList<T>, HashSet<T>, BTreeSet<T>);
+
+impl<T: TsName> TsName for [T] {
+    const NAME_LEN: u32 = <T as TsName>::NAME_LEN + 2;
+
+    #[inline]
+    fn describe_name() {
+        <T as TsName>::describe_name();
+        inform_char('[');
+        inform_char(']');
+    }
+}
+
+impl<T: TsName, const N: usize> TsName for [T; N] {
+    const NAME_LEN: u32 = <T as TsName>::NAME_LEN + 2;
+
+    #[inline]
+    fn describe_name() {
+        <T as TsName>::describe_name();
+        inform_char('[');
+        inform_char(']');
+    }
+}
+
+// `Map` while serde-wasm-bindgen is producing a real `Map`, `Record` once the
+// value has been through JSON and come out an object.
+#[cfg(feature = "js")]
+const MAP_NAME_LEN: u32 = 3;
+#[cfg(not(feature = "js"))]
+const MAP_NAME_LEN: u32 = 6;
+
+// Spelled out rather than walked out of a `const` array: an indexing expression
+// materializes the array in memory, and memory reads at describe time come back
+// zeroed. See [`TsName`].
+#[cfg(feature = "js")]
+fn describe_map_name() {
+    inform_char('M');
+    inform_char('a');
+    inform_char('p');
+}
+
+#[cfg(not(feature = "js"))]
+fn describe_map_name() {
+    inform_char('R');
+    inform_char('e');
+    inform_char('c');
+    inform_char('o');
+    inform_char('r');
+    inform_char('d');
+}
+
+macro_rules! ts_name_map {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<K: TsName, V: TsName> TsName for $ty {
+                // `Map<` + K + `, ` + V + `>`
+                const NAME_LEN: u32 = MAP_NAME_LEN
+                    + 4
+                    + <K as TsName>::NAME_LEN
+                    + <V as TsName>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    describe_map_name();
+                    inform_char('<');
+                    <K as TsName>::describe_name();
+                    inform_char(',');
+                    inform_char(' ');
+                    <V as TsName>::describe_name();
+                    inform_char('>');
+                }
+            }
+        )+
+    };
+}
+
+ts_name_map!(HashMap<K, V>, BTreeMap<K, V>);
+
+// The nullish half matches what the declaration uses: `undefined` while
+// serde-wasm-bindgen leaves a missing value undefined, `null` once it has been
+// through JSON.
+#[cfg(feature = "js")]
+const NULLISH_LEN: u32 = 9;
+#[cfg(not(feature = "js"))]
+const NULLISH_LEN: u32 = 4;
+
+#[cfg(feature = "js")]
+fn describe_nullish() {
+    inform_char('u');
+    inform_char('n');
+    inform_char('d');
+    inform_char('e');
+    inform_char('f');
+    inform_char('i');
+    inform_char('n');
+    inform_char('e');
+    inform_char('d');
+}
+
+#[cfg(not(feature = "js"))]
+fn describe_nullish() {
+    inform_char('n');
+    inform_char('u');
+    inform_char('l');
+    inform_char('l');
+}
+
+/// The unit type serializes to nothing, and is named for whatever that nothing
+/// comes out as.
+impl TsName for () {
+    const NAME_LEN: u32 = NULLISH_LEN;
+
+    #[inline]
+    fn describe_name() {
+        describe_nullish();
+    }
+}
+
+/// `(T | undefined)`.
+///
+/// The parentheses are always written. A union is only legal unparenthesized in
+/// some of the positions a name can land in — `Vec<Option<T>>` has to come out
+/// as `(T | undefined)[]` — and a name has no context to decide from at
+/// describe time.
+impl<T: TsName> TsName for Option<T> {
+    // `(` + T + ` | ` + nullish + `)`
+    const NAME_LEN: u32 = <T as TsName>::NAME_LEN + NULLISH_LEN + 5;
+
+    #[inline]
+    fn describe_name() {
+        inform_char('(');
+        <T as TsName>::describe_name();
+        inform_char(' ');
+        inform_char('|');
+        inform_char(' ');
+        describe_nullish();
+        inform_char(')');
+    }
+}

--- a/src/ts.rs
+++ b/src/ts.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::mem::ManuallyDrop;
 
 use crate::Error;
+use crate::TsName;
 use crate::Tsify;
 use wasm_bindgen::convert::{
     FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi,
@@ -129,17 +130,19 @@ where
 
 impl<T> WasmDescribe for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: WasmDescribe,
 {
+    // Not `JsType::describe()`: the extern type carries one fixed name, which
+    // for a generic `T` would drop its arguments. See `TsName`.
     fn describe() {
-        <T as Tsify>::JsType::describe()
+        <T as TsName>::describe_named_externref()
     }
 }
 
 impl<T> IntoWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: IntoWasmAbi,
 {
     type Abi = <T::JsType as IntoWasmAbi>::Abi;
@@ -149,7 +152,7 @@ where
 }
 impl<'a, T> IntoWasmAbi for &'a Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: JsCast + WasmDescribe,
 {
     type Abi = <&'a JsValue as IntoWasmAbi>::Abi;
@@ -161,7 +164,7 @@ where
 }
 impl<T> FromWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: FromWasmAbi,
 {
     type Abi = <T::JsType as FromWasmAbi>::Abi;
@@ -172,7 +175,7 @@ where
 
 impl<T> OptionIntoWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: OptionIntoWasmAbi,
 {
     fn none() -> Self::Abi {
@@ -182,7 +185,7 @@ where
 
 impl<T> OptionFromWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: OptionFromWasmAbi,
 {
     fn is_none(abi: &Self::Abi) -> bool {
@@ -192,7 +195,7 @@ where
 
 impl<T> RefFromWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: RefFromWasmAbi,
 {
     // JsValue uses ManuallyDrop.
@@ -208,7 +211,7 @@ where
 
 impl<T> LongRefFromWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: LongRefFromWasmAbi,
 {
     type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
@@ -222,17 +225,17 @@ where
 
 impl<T> WasmDescribeVector for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: WasmDescribeVector,
 {
     fn describe_vector() {
-        <T as Tsify>::JsType::describe_vector()
+        <T as TsName>::describe_named_externref_vector()
     }
 }
 
 impl<T> VectorFromWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: VectorFromWasmAbi,
 {
     type Abi = <<T as Tsify>::JsType as VectorFromWasmAbi>::Abi;
@@ -249,7 +252,7 @@ where
 
 impl<T> VectorIntoWasmAbi for Ts<T>
 where
-    T: Tsify,
+    T: Tsify + TsName,
     <T as Tsify>::JsType: VectorIntoWasmAbi,
 {
     type Abi = <<T as Tsify>::JsType as VectorIntoWasmAbi>::Abi;

--- a/tests-e2e/reference_output/test7/test7.d.ts
+++ b/tests-e2e/reference_output/test7/test7.d.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * A parameter no field mentions is not part of the declaration, so it is not
+ * part of the name either.
+ */
+export interface Tagged {
+    id: number;
+}
+
+export interface Pair<A, B> {
+    left: A;
+    right: B;
+}
+
+export interface Response<T> {
+    data: T;
+    ok: boolean;
+}
+
+export interface UserInfo {
+    id: number;
+    name: string;
+}
+
+export type Outcome<T> = { Done: T } | { Failed: string };
+
+
+export function builtin_argument(): Response<string[]>;
+
+export function generic_enum(): Outcome<UserInfo>;
+
+export function get_user(): Response<UserInfo>;
+
+export function map_argument(): Response<Record<string, number>>;
+
+export function nested(): Response<Response<UserInfo>>;
+
+export function optional_argument(): Response<(UserInfo | null)>;
+
+export function put_user(response: Response<UserInfo>): boolean;
+
+/**
+ * The same thing through `Ts`, which is the way to cross the ABI without the
+ * leak `into_wasm_abi`/`from_wasm_abi` have.
+ */
+export function round_trip(response: Response<UserInfo>): Response<UserInfo>;
+
+export function several_arguments(): Response<Pair<number, string>>;
+
+export function undeclared_parameter(): Tagged;

--- a/tests-e2e/test7/Cargo.toml
+++ b/tests-e2e/test7/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test7"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"

--- a/tests-e2e/test7/entry_point.rs
+++ b/tests-e2e/test7/entry_point.rs
@@ -1,0 +1,124 @@
+//! Generic types keep their arguments in the signatures wasm-bindgen writes.
+#![allow(deprecated)]
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tsify::{Ts, Tsify};
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct UserInfo {
+    id: u32,
+    name: String,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct Response<T> {
+    data: T,
+    ok: bool,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Pair<A, B> {
+    left: A,
+    right: B,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi)]
+pub enum Outcome<T> {
+    Done(T),
+    Failed(String),
+}
+
+/// A parameter no field mentions is not part of the declaration, so it is not
+/// part of the name either.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi)]
+pub struct Tagged<T> {
+    #[serde(skip)]
+    tag: std::marker::PhantomData<T>,
+    id: u32,
+}
+
+#[wasm_bindgen]
+pub fn get_user() -> Response<UserInfo> {
+    Response {
+        data: UserInfo {
+            id: 0,
+            name: String::new(),
+        },
+        ok: true,
+    }
+}
+
+#[wasm_bindgen]
+pub fn put_user(response: Response<UserInfo>) -> bool {
+    response.ok
+}
+
+#[wasm_bindgen]
+pub fn nested() -> Response<Response<UserInfo>> {
+    Response {
+        data: get_user(),
+        ok: true,
+    }
+}
+
+#[wasm_bindgen]
+pub fn builtin_argument() -> Response<Vec<String>> {
+    Response {
+        data: Vec::new(),
+        ok: true,
+    }
+}
+
+#[wasm_bindgen]
+pub fn optional_argument() -> Response<Option<UserInfo>> {
+    Response {
+        data: None,
+        ok: true,
+    }
+}
+
+#[wasm_bindgen]
+pub fn map_argument() -> Response<HashMap<String, u32>> {
+    Response {
+        data: HashMap::new(),
+        ok: true,
+    }
+}
+
+#[wasm_bindgen]
+pub fn several_arguments() -> Response<Pair<u32, String>> {
+    Response {
+        data: Pair {
+            left: 0,
+            right: String::new(),
+        },
+        ok: true,
+    }
+}
+
+#[wasm_bindgen]
+pub fn generic_enum() -> Outcome<UserInfo> {
+    Outcome::Failed(String::new())
+}
+
+#[wasm_bindgen]
+pub fn undeclared_parameter() -> Tagged<UserInfo> {
+    Tagged {
+        tag: std::marker::PhantomData,
+        id: 0,
+    }
+}
+
+/// The same thing through `Ts`, which is the way to cross the ABI without the
+/// leak `into_wasm_abi`/`from_wasm_abi` have.
+#[wasm_bindgen]
+pub fn round_trip(response: Ts<Response<UserInfo>>) -> Result<Ts<Response<UserInfo>>, JsError> {
+    let response: Response<UserInfo> = response.to_rust()?;
+    Ok(response.into_ts()?)
+}

--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -53,7 +53,10 @@ fn assert_diagnostic(stderr: &str, case: &CompileFailCase) {
             .map_or(diagnostic.len(), |index| index + 1);
         let diagnostic = &diagnostic[..diagnostic_end];
 
-        if diagnostic.contains(&location) {
+        // rustc spells the path with the platform's separator, so the same
+        // diagnostic points at `src/module.rs` on Unix and `src\module.rs` on
+        // Windows. Compare one spelling.
+        if diagnostic.replace('\\', "/").contains(&location) {
             return;
         }
         search_start = error_start + error.len();

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -231,17 +231,30 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<'a> tsify::TsName for Borrow<'a> {
+        const NAME_LEN: u32 = 6u32;
+        #[inline]
+        fn describe_name() {
+            tsify::inform_char('B');
+            tsify::inform_char('o');
+            tsify::inform_char('r');
+            tsify::inform_char('r');
+            tsify::inform_char('o');
+            tsify::inform_char('w');
+        }
+    }
+    #[automatically_derived]
     impl<'a> WasmDescribe for Borrow<'a> {
         #[inline]
         fn describe() {
-            <Self as Tsify>::JsType::describe()
+            <Self as tsify::TsName>::describe_named_externref()
         }
     }
     #[automatically_derived]
     impl<'a> WasmDescribeVector for Borrow<'a> {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]

--- a/tests/expand/generic_constrained_struct.expanded.rs
+++ b/tests/expand/generic_constrained_struct.expanded.rs
@@ -237,22 +237,55 @@ const _: () = {
         };
     }
     #[automatically_derived]
-    impl<T: Constraint> WasmDescribe for GenericStruct<T> {
+    impl<T: Constraint> tsify::TsName for GenericStruct<T>
+    where
+        T: tsify::TsName,
+    {
+        const NAME_LEN: u32 = 15u32 + <T as tsify::TsName>::NAME_LEN;
         #[inline]
-        fn describe() {
-            <Self as Tsify>::JsType::describe()
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('S');
+            tsify::inform_char('t');
+            tsify::inform_char('r');
+            tsify::inform_char('u');
+            tsify::inform_char('c');
+            tsify::inform_char('t');
+            tsify::inform_char('<');
+            <T as tsify::TsName>::describe_name();
+            tsify::inform_char('>');
         }
     }
     #[automatically_derived]
-    impl<T: Constraint> WasmDescribeVector for GenericStruct<T> {
+    impl<T: Constraint> WasmDescribe for GenericStruct<T>
+    where
+        T: tsify::TsName,
+    {
+        #[inline]
+        fn describe() {
+            <Self as tsify::TsName>::describe_named_externref()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> WasmDescribeVector for GenericStruct<T>
+    where
+        T: tsify::TsName,
+    {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
     impl<T: Constraint> IntoWasmAbi for &GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -280,6 +313,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> IntoWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -291,6 +325,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> OptionIntoWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         #[inline]
@@ -301,6 +336,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> From<GenericStruct<T>> for JsValue
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         #[inline]
@@ -327,6 +363,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> VectorIntoWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as VectorIntoWasmAbi>::Abi;
@@ -358,6 +395,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> FromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as FromWasmAbi>::Abi;
@@ -373,6 +411,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> OptionFromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         #[inline]
@@ -391,6 +430,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> RefFromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as RefFromWasmAbi>::Abi;
@@ -406,6 +446,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> VectorFromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as VectorFromWasmAbi>::Abi;
@@ -668,22 +709,56 @@ const _: () = {
         };
     }
     #[automatically_derived]
-    impl<T: Constraint> WasmDescribe for GenericNewtype<T> {
+    impl<T: Constraint> tsify::TsName for GenericNewtype<T>
+    where
+        T: tsify::TsName,
+    {
+        const NAME_LEN: u32 = 16u32 + <T as tsify::TsName>::NAME_LEN;
         #[inline]
-        fn describe() {
-            <Self as Tsify>::JsType::describe()
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('N');
+            tsify::inform_char('e');
+            tsify::inform_char('w');
+            tsify::inform_char('t');
+            tsify::inform_char('y');
+            tsify::inform_char('p');
+            tsify::inform_char('e');
+            tsify::inform_char('<');
+            <T as tsify::TsName>::describe_name();
+            tsify::inform_char('>');
         }
     }
     #[automatically_derived]
-    impl<T: Constraint> WasmDescribeVector for GenericNewtype<T> {
+    impl<T: Constraint> WasmDescribe for GenericNewtype<T>
+    where
+        T: tsify::TsName,
+    {
+        #[inline]
+        fn describe() {
+            <Self as tsify::TsName>::describe_named_externref()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Constraint> WasmDescribeVector for GenericNewtype<T>
+    where
+        T: tsify::TsName,
+    {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
     impl<T: Constraint> IntoWasmAbi for &GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -711,6 +786,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> IntoWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -722,6 +798,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> OptionIntoWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         #[inline]
@@ -732,6 +809,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> From<GenericNewtype<T>> for JsValue
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         #[inline]
@@ -758,6 +836,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> VectorIntoWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as VectorIntoWasmAbi>::Abi;
@@ -789,6 +868,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> FromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as FromWasmAbi>::Abi;
@@ -804,6 +884,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> OptionFromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         #[inline]
@@ -822,6 +903,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> RefFromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as RefFromWasmAbi>::Abi;
@@ -837,6 +919,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Constraint> VectorFromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as VectorFromWasmAbi>::Abi;
@@ -1099,22 +1182,54 @@ const _: () = {
         };
     }
     #[automatically_derived]
-    impl<T: Iterator<Item = u32>> WasmDescribe for GenericAssoc<T> {
+    impl<T: Iterator<Item = u32>> tsify::TsName for GenericAssoc<T>
+    where
+        T: tsify::TsName,
+    {
+        const NAME_LEN: u32 = 14u32 + <T as tsify::TsName>::NAME_LEN;
         #[inline]
-        fn describe() {
-            <Self as Tsify>::JsType::describe()
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('A');
+            tsify::inform_char('s');
+            tsify::inform_char('s');
+            tsify::inform_char('o');
+            tsify::inform_char('c');
+            tsify::inform_char('<');
+            <T as tsify::TsName>::describe_name();
+            tsify::inform_char('>');
         }
     }
     #[automatically_derived]
-    impl<T: Iterator<Item = u32>> WasmDescribeVector for GenericAssoc<T> {
+    impl<T: Iterator<Item = u32>> WasmDescribe for GenericAssoc<T>
+    where
+        T: tsify::TsName,
+    {
+        #[inline]
+        fn describe() {
+            <Self as tsify::TsName>::describe_named_externref()
+        }
+    }
+    #[automatically_derived]
+    impl<T: Iterator<Item = u32>> WasmDescribeVector for GenericAssoc<T>
+    where
+        T: tsify::TsName,
+    {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> IntoWasmAbi for &GenericAssoc<T>
     where
+        T: tsify::TsName,
         GenericAssoc<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -1142,6 +1257,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> IntoWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         GenericAssoc<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -1153,6 +1269,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> OptionIntoWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         GenericAssoc<T>: _serde::Serialize,
     {
         #[inline]
@@ -1163,6 +1280,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> From<GenericAssoc<T>> for JsValue
     where
+        T: tsify::TsName,
         GenericAssoc<T>: _serde::Serialize,
     {
         #[inline]
@@ -1189,6 +1307,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> VectorIntoWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         GenericAssoc<T>: _serde::Serialize,
     {
         type Abi = <JsType as VectorIntoWasmAbi>::Abi;
@@ -1220,6 +1339,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> FromWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as FromWasmAbi>::Abi;
@@ -1235,6 +1355,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> OptionFromWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         #[inline]
@@ -1253,6 +1374,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> RefFromWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as RefFromWasmAbi>::Abi;
@@ -1268,6 +1390,7 @@ const _: () = {
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> VectorFromWasmAbi for GenericAssoc<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as VectorFromWasmAbi>::Abi;
@@ -1534,17 +1657,39 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<'a: 'b, 'b> tsify::TsName for GenericLifetime<'a, 'b> {
+        const NAME_LEN: u32 = 15u32;
+        #[inline]
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('L');
+            tsify::inform_char('i');
+            tsify::inform_char('f');
+            tsify::inform_char('e');
+            tsify::inform_char('t');
+            tsify::inform_char('i');
+            tsify::inform_char('m');
+            tsify::inform_char('e');
+        }
+    }
+    #[automatically_derived]
     impl<'a: 'b, 'b> WasmDescribe for GenericLifetime<'a, 'b> {
         #[inline]
         fn describe() {
-            <Self as Tsify>::JsType::describe()
+            <Self as tsify::TsName>::describe_named_externref()
         }
     }
     #[automatically_derived]
     impl<'a: 'b, 'b> WasmDescribeVector for GenericLifetime<'a, 'b> {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
@@ -1965,17 +2110,36 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<const N: usize> tsify::TsName for GenericConst<N> {
+        const NAME_LEN: u32 = 12u32;
+        #[inline]
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('C');
+            tsify::inform_char('o');
+            tsify::inform_char('n');
+            tsify::inform_char('s');
+            tsify::inform_char('t');
+        }
+    }
+    #[automatically_derived]
     impl<const N: usize> WasmDescribe for GenericConst<N> {
         #[inline]
         fn describe() {
-            <Self as Tsify>::JsType::describe()
+            <Self as tsify::TsName>::describe_named_externref()
         }
     }
     #[automatically_derived]
     impl<const N: usize> WasmDescribeVector for GenericConst<N> {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -237,22 +237,61 @@ const _: () = {
         };
     }
     #[automatically_derived]
-    impl<T, U> WasmDescribe for GenericEnum<T, U> {
+    impl<T, U> tsify::TsName for GenericEnum<T, U>
+    where
+        T: tsify::TsName,
+        U: tsify::TsName,
+    {
+        const NAME_LEN: u32 = 15u32 + <T as tsify::TsName>::NAME_LEN
+            + <U as tsify::TsName>::NAME_LEN;
         #[inline]
-        fn describe() {
-            <Self as Tsify>::JsType::describe()
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('E');
+            tsify::inform_char('n');
+            tsify::inform_char('u');
+            tsify::inform_char('m');
+            tsify::inform_char('<');
+            <T as tsify::TsName>::describe_name();
+            tsify::inform_char(',');
+            tsify::inform_char(' ');
+            <U as tsify::TsName>::describe_name();
+            tsify::inform_char('>');
         }
     }
     #[automatically_derived]
-    impl<T, U> WasmDescribeVector for GenericEnum<T, U> {
+    impl<T, U> WasmDescribe for GenericEnum<T, U>
+    where
+        T: tsify::TsName,
+        U: tsify::TsName,
+    {
+        #[inline]
+        fn describe() {
+            <Self as tsify::TsName>::describe_named_externref()
+        }
+    }
+    #[automatically_derived]
+    impl<T, U> WasmDescribeVector for GenericEnum<T, U>
+    where
+        T: tsify::TsName,
+        U: tsify::TsName,
+    {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
     impl<T, U> IntoWasmAbi for &GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         GenericEnum<T, U>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -280,6 +319,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> IntoWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         GenericEnum<T, U>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -291,6 +332,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> OptionIntoWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         GenericEnum<T, U>: _serde::Serialize,
     {
         #[inline]
@@ -301,6 +344,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> From<GenericEnum<T, U>> for JsValue
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         GenericEnum<T, U>: _serde::Serialize,
     {
         #[inline]
@@ -327,6 +372,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> VectorIntoWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         GenericEnum<T, U>: _serde::Serialize,
     {
         type Abi = <JsType as VectorIntoWasmAbi>::Abi;
@@ -358,6 +405,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> FromWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as FromWasmAbi>::Abi;
@@ -373,6 +422,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> OptionFromWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         #[inline]
@@ -391,6 +442,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> RefFromWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as RefFromWasmAbi>::Abi;
@@ -406,6 +459,8 @@ const _: () = {
     #[automatically_derived]
     impl<T, U> VectorFromWasmAbi for GenericEnum<T, U>
     where
+        T: tsify::TsName,
+        U: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as VectorFromWasmAbi>::Abi;

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -236,22 +236,55 @@ const _: () = {
         };
     }
     #[automatically_derived]
-    impl<T> WasmDescribe for GenericStruct<T> {
+    impl<T> tsify::TsName for GenericStruct<T>
+    where
+        T: tsify::TsName,
+    {
+        const NAME_LEN: u32 = 15u32 + <T as tsify::TsName>::NAME_LEN;
         #[inline]
-        fn describe() {
-            <Self as Tsify>::JsType::describe()
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('S');
+            tsify::inform_char('t');
+            tsify::inform_char('r');
+            tsify::inform_char('u');
+            tsify::inform_char('c');
+            tsify::inform_char('t');
+            tsify::inform_char('<');
+            <T as tsify::TsName>::describe_name();
+            tsify::inform_char('>');
         }
     }
     #[automatically_derived]
-    impl<T> WasmDescribeVector for GenericStruct<T> {
+    impl<T> WasmDescribe for GenericStruct<T>
+    where
+        T: tsify::TsName,
+    {
+        #[inline]
+        fn describe() {
+            <Self as tsify::TsName>::describe_named_externref()
+        }
+    }
+    #[automatically_derived]
+    impl<T> WasmDescribeVector for GenericStruct<T>
+    where
+        T: tsify::TsName,
+    {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
     impl<T> IntoWasmAbi for &GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -279,6 +312,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> IntoWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -290,6 +324,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> OptionIntoWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         #[inline]
@@ -300,6 +335,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> From<GenericStruct<T>> for JsValue
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         #[inline]
@@ -326,6 +362,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> VectorIntoWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         GenericStruct<T>: _serde::Serialize,
     {
         type Abi = <JsType as VectorIntoWasmAbi>::Abi;
@@ -357,6 +394,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> FromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as FromWasmAbi>::Abi;
@@ -372,6 +410,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> OptionFromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         #[inline]
@@ -390,6 +429,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> RefFromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as RefFromWasmAbi>::Abi;
@@ -405,6 +445,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> VectorFromWasmAbi for GenericStruct<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as VectorFromWasmAbi>::Abi;
@@ -667,22 +708,56 @@ const _: () = {
         };
     }
     #[automatically_derived]
-    impl<T> WasmDescribe for GenericNewtype<T> {
+    impl<T> tsify::TsName for GenericNewtype<T>
+    where
+        T: tsify::TsName,
+    {
+        const NAME_LEN: u32 = 16u32 + <T as tsify::TsName>::NAME_LEN;
         #[inline]
-        fn describe() {
-            <Self as Tsify>::JsType::describe()
+        fn describe_name() {
+            tsify::inform_char('G');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('e');
+            tsify::inform_char('r');
+            tsify::inform_char('i');
+            tsify::inform_char('c');
+            tsify::inform_char('N');
+            tsify::inform_char('e');
+            tsify::inform_char('w');
+            tsify::inform_char('t');
+            tsify::inform_char('y');
+            tsify::inform_char('p');
+            tsify::inform_char('e');
+            tsify::inform_char('<');
+            <T as tsify::TsName>::describe_name();
+            tsify::inform_char('>');
         }
     }
     #[automatically_derived]
-    impl<T> WasmDescribeVector for GenericNewtype<T> {
+    impl<T> WasmDescribe for GenericNewtype<T>
+    where
+        T: tsify::TsName,
+    {
+        #[inline]
+        fn describe() {
+            <Self as tsify::TsName>::describe_named_externref()
+        }
+    }
+    #[automatically_derived]
+    impl<T> WasmDescribeVector for GenericNewtype<T>
+    where
+        T: tsify::TsName,
+    {
         #[inline]
         fn describe_vector() {
-            <Self as Tsify>::JsType::describe_vector()
+            <Self as tsify::TsName>::describe_named_externref_vector()
         }
     }
     #[automatically_derived]
     impl<T> IntoWasmAbi for &GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -710,6 +785,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> IntoWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as IntoWasmAbi>::Abi;
@@ -721,6 +797,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> OptionIntoWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         #[inline]
@@ -731,6 +808,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> From<GenericNewtype<T>> for JsValue
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         #[inline]
@@ -757,6 +835,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> VectorIntoWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         GenericNewtype<T>: _serde::Serialize,
     {
         type Abi = <JsType as VectorIntoWasmAbi>::Abi;
@@ -788,6 +867,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> FromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as FromWasmAbi>::Abi;
@@ -803,6 +883,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> OptionFromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         #[inline]
@@ -821,6 +902,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> RefFromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as RefFromWasmAbi>::Abi;
@@ -836,6 +918,7 @@ const _: () = {
     #[automatically_derived]
     impl<T> VectorFromWasmAbi for GenericNewtype<T>
     where
+        T: tsify::TsName,
         Self: _serde::de::DeserializeOwned,
     {
         type Abi = <JsType as VectorFromWasmAbi>::Abi;

--- a/tests/expand/rename.expanded.rs
+++ b/tests/expand/rename.expanded.rs
@@ -236,4 +236,26 @@ const _: () = {
             large_number_types_as_bigints: false,
         };
     }
+    #[automatically_derived]
+    impl tsify::TsName for RustType {
+        const NAME_LEN: u32 = 15u32;
+        #[inline]
+        fn describe_name() {
+            tsify::inform_char('R');
+            tsify::inform_char('e');
+            tsify::inform_char('n');
+            tsify::inform_char('a');
+            tsify::inform_char('m');
+            tsify::inform_char('e');
+            tsify::inform_char('d');
+            tsify::inform_char('W');
+            tsify::inform_char('a');
+            tsify::inform_char('s');
+            tsify::inform_char('m');
+            tsify::inform_char('T');
+            tsify::inform_char('y');
+            tsify::inform_char('p');
+            tsify::inform_char('e');
+        }
+    }
 };

--- a/tests/name.rs
+++ b/tests/name.rs
@@ -1,0 +1,109 @@
+//! The names generic types describe themselves by.
+//!
+//! Only the length is checked here: informing the characters themselves needs
+//! wasm-bindgen's descriptor import, which only exists in a wasm build. What
+//! the characters come out as is covered by `tests-e2e/test7`, which reads the
+//! `.d.ts` wasm-bindgen writes.
+//!
+//! A length that disagrees with the characters is the failure worth catching:
+//! wasm-bindgen reads the name as a count followed by that many characters, so
+//! a wrong count does not truncate a name, it desynchronizes the rest of the
+//! descriptor.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tsify::{TsName, Tsify};
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct UserInfo {
+    id: u32,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Response<T> {
+    data: T,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Pair<A, B> {
+    left: A,
+    right: B,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(rename = "Renamed")]
+pub struct Named<T> {
+    data: T,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Tagged<T> {
+    #[serde(skip)]
+    tag: std::marker::PhantomData<T>,
+    id: u32,
+}
+
+#[derive(Tsify, Serialize)]
+pub struct Sliced<'a, const N: usize> {
+    data: &'a str,
+}
+
+#[track_caller]
+fn assert_name_len<T: TsName>(expected: &str) {
+    assert_eq!(
+        <T as TsName>::NAME_LEN,
+        expected.chars().count() as u32,
+        "name length for `{expected}`"
+    );
+}
+
+#[test]
+fn test_plain_name() {
+    assert_name_len::<UserInfo>("UserInfo");
+}
+
+#[test]
+fn test_generic_name() {
+    assert_name_len::<Response<UserInfo>>("Response<UserInfo>");
+}
+
+#[test]
+fn test_nested_generic_name() {
+    assert_name_len::<Response<Response<UserInfo>>>("Response<Response<UserInfo>>");
+}
+
+#[test]
+fn test_several_type_arguments() {
+    assert_name_len::<Pair<u32, String>>("Pair<number, string>");
+    assert_name_len::<Response<Pair<u32, String>>>("Response<Pair<number, string>>");
+}
+
+#[test]
+fn test_builtin_type_arguments() {
+    assert_name_len::<Response<Vec<String>>>("Response<string[]>");
+    assert_name_len::<Response<bool>>("Response<boolean>");
+    assert_name_len::<Response<Box<UserInfo>>>("Response<UserInfo>");
+
+    if cfg!(feature = "js") {
+        assert_name_len::<Response<Option<UserInfo>>>("Response<(UserInfo | undefined)>");
+        assert_name_len::<Response<HashMap<String, u32>>>("Response<Map<string, number>>");
+    } else {
+        assert_name_len::<Response<Option<UserInfo>>>("Response<(UserInfo | null)>");
+        assert_name_len::<Response<HashMap<String, u32>>>("Response<Record<string, number>>");
+    }
+}
+
+#[test]
+fn test_name_follows_the_declaration() {
+    // `rename` names the declaration, so it names the type.
+    assert_name_len::<Named<UserInfo>>("Renamed<UserInfo>");
+
+    // A parameter no field mentions is declared nowhere, so applying it to the
+    // declared name would be a type error in the `.d.ts`.
+    assert_name_len::<Tagged<UserInfo>>("Tagged");
+
+    // Neither lifetimes nor const parameters reach TypeScript at all.
+    assert_name_len::<Sliced<'_, 3>>("Sliced");
+}

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -312,6 +312,16 @@ impl Decl {
             Decl::TsEnum(decl) => &decl.id,
         }
     }
+
+    /// The parameters the declaration takes, which is not every parameter the
+    /// Rust type takes: one that no field mentions has nothing to declare.
+    pub fn type_params(&self) -> &[String] {
+        match self {
+            Decl::TsTypeAlias(decl) => &decl.type_params,
+            Decl::TsInterface(decl) => &decl.type_params,
+            Decl::TsEnum(decl) => &decl.type_params,
+        }
+    }
 }
 
 impl Display for Decl {

--- a/tsify-macros/src/wasm_bindgen.rs
+++ b/tsify-macros/src/wasm_bindgen.rs
@@ -25,6 +25,13 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     let generics = cont.generics_without_defaults();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    // The name the type describes itself by is composed from its arguments, so
+    // everything that goes through `WasmDescribe` needs them to have names too.
+    let name_params = name_type_params(cont, &decl).unwrap_or_default();
+    let name_generics = generics_with_ts_name(cont, &name_params);
+    let ts_name = expand_ts_name(cont, &decl, &name_params, &name_generics);
+    let (name_impl_generics, name_ty_generics, name_where_clause) = name_generics.split_for_impl();
+
     let typescript_custom_section = quote! {
         #[wasm_bindgen(typescript_custom_section)]
         const TS_APPEND_CONTENT: &'static str = #decl_str;
@@ -35,18 +42,21 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     let wasm_describe = wasm_abi.then(|| {
         quote! {
             #[automatically_derived]
-            impl #impl_generics WasmDescribe for #ident #ty_generics #where_clause {
+            impl #name_impl_generics WasmDescribe for #ident #name_ty_generics #name_where_clause {
+                // Not `JsType::describe()`: the extern type below carries one
+                // fixed name, which for a generic type would drop its
+                // arguments. See `tsify::TsName`.
                 #[inline]
                 fn describe() {
-                    <Self as Tsify>::JsType::describe()
+                    <Self as tsify::TsName>::describe_named_externref()
                 }
             }
 
             #[automatically_derived]
-            impl #impl_generics WasmDescribeVector for #ident #ty_generics #where_clause {
+            impl #name_impl_generics WasmDescribeVector for #ident #name_ty_generics #name_where_clause {
                 #[inline]
                 fn describe_vector() {
-                    <Self as Tsify>::JsType::describe_vector()
+                    <Self as tsify::TsName>::describe_named_externref_vector()
                 }
             }
         }
@@ -61,8 +71,12 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
         },
     });
 
-    let into_wasm_abi = attrs.into_wasm_abi.then(|| expand_into_wasm_abi(cont));
-    let from_wasm_abi = attrs.from_wasm_abi.then(|| expand_from_wasm_abi(cont));
+    let into_wasm_abi = attrs
+        .into_wasm_abi
+        .then(|| expand_into_wasm_abi(cont, &name_generics));
+    let from_wasm_abi = attrs
+        .from_wasm_abi
+        .then(|| expand_from_wasm_abi(cont, &name_generics));
     let maybe_deprecated = attrs.into_wasm_abi_span
         .or(attrs.from_wasm_abi_span)
         .map(|span| {
@@ -104,6 +118,7 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
                 };
             }
 
+            #ts_name
             #typescript_custom_section
             #wasm_describe
             #into_wasm_abi
@@ -113,10 +128,109 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     }
 }
 
-fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
+/// The declaration's parameters, resolved back to the Rust type parameters they
+/// name.
+///
+/// `None` when one of them names no Rust parameter — `#[tsify(type_params)]`
+/// can say anything — which leaves nothing to compose that argument's name
+/// from, so the type keeps describing itself by its bare id as it did before.
+fn name_type_params(cont: &Container, decl: &Decl) -> Option<Vec<syn::Ident>> {
+    decl.type_params()
+        .iter()
+        .map(|declared| {
+            cont.generics()
+                .type_params()
+                .find(|param| param.ident == *declared)
+                .map(|param| param.ident.clone())
+        })
+        .collect()
+}
+
+/// The type's generics, plus the `TsName` bound every parameter that appears in
+/// its name needs. A parameter no field mentions is left alone: it is not part
+/// of the name, so it has no name to contribute.
+fn generics_with_ts_name(cont: &Container, name_params: &[syn::Ident]) -> syn::Generics {
+    let mut generics = cont.generics_without_defaults();
+
+    if !name_params.is_empty() {
+        let where_clause = generics.make_where_clause();
+        for param in name_params {
+            where_clause
+                .predicates
+                .push(parse_quote!(#param: tsify::TsName));
+        }
+    }
+
+    generics
+}
+
+/// Spells out the type's TypeScript name for `tsify::TsName`, one `char` at a
+/// time, deferring to each argument's own impl for the arguments.
+///
+/// Unrolled rather than informed from `DECL`'s id because wasm-bindgen reads the
+/// descriptor without the module's data segments loaded, so a character that
+/// comes from memory reaches it as `\0`.
+fn expand_ts_name(
+    cont: &Container,
+    decl: &Decl,
+    name_params: &[syn::Ident],
+    generics: &syn::Generics,
+) -> TokenStream {
+    let ident = cont.ident();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let id_chars = decl.id().chars().collect::<Vec<_>>();
+    let id_len = id_chars.len() as u32;
+    let id = quote!(#(tsify::inform_char(#id_chars);)*);
+
+    let (name_len, describe_name) = if name_params.is_empty() {
+        (quote!(#id_len), id)
+    } else {
+        // The id, `<`, `>`, and `, ` between each pair of arguments.
+        let punctuation = id_len + 2 + 2 * (name_params.len() as u32 - 1);
+
+        let args = name_params.iter().enumerate().map(|(i, param)| {
+            let separator = (i > 0).then(|| {
+                quote! {
+                    tsify::inform_char(',');
+                    tsify::inform_char(' ');
+                }
+            });
+
+            quote! {
+                #separator
+                <#param as tsify::TsName>::describe_name();
+            }
+        });
+
+        (
+            quote!(#punctuation #(+ <#name_params as tsify::TsName>::NAME_LEN)*),
+            quote! {
+                #id
+                tsify::inform_char('<');
+                #(#args)*
+                tsify::inform_char('>');
+            },
+        )
+    };
+
+    quote! {
+        #[automatically_derived]
+        impl #impl_generics tsify::TsName for #ident #ty_generics #where_clause {
+            const NAME_LEN: u32 = #name_len;
+
+            #[inline]
+            fn describe_name() {
+                #describe_name
+            }
+        }
+    }
+}
+
+fn expand_into_wasm_abi(cont: &Container, name_generics: &syn::Generics) -> TokenStream {
     let ident = cont.ident();
     let serde_path = cont.serde_container.attrs.serde_path();
-    let mut generics = cont.generics_without_defaults();
+    let mut generics = name_generics.clone();
 
     // A predicate's self type is a type position, where `Generics` would render
     // its declaration form — bounds, defaults, `const N: usize` — and hit E0229.
@@ -221,11 +335,11 @@ fn expand_into_wasm_abi(cont: &Container) -> TokenStream {
     }
 }
 
-fn expand_from_wasm_abi(cont: &Container) -> TokenStream {
+fn expand_from_wasm_abi(cont: &Container, name_generics: &syn::Generics) -> TokenStream {
     let ident = cont.ident();
     let serde_path = cont.serde_container.attrs.serde_path();
 
-    let mut generics = cont.generics_without_defaults();
+    let mut generics = name_generics.clone();
 
     generics
         .make_where_clause()


### PR DESCRIPTION
Previously, generic type parameters of parameter and return types were not included in the generated ts types.
The following:
```rust
#[derive(Debug, Serialize, Deserialize, Tsify)]
pub struct Foo<T>(T);

#[wasm_bindgen]
pub fn bar(foo: Ts<Foo<64>>) {
   unimplemented!();
}
```
generated the types:
```typescript
export type Foo<T> = T;
export function bar(foo: Foo): void;
```
Typescript treats `Foo` with missing generic parameters like here as `any`!

The workaround is, to create a new type like this:
```typescript
#[derive(Debug, Serialize, Deserialize, Tsify)]
struct FooI64(Foo<i64>);
````

# Cause
This was caused by where wasm-bindgen gets the type from. It does not read the typescript_custom_section when writing a signature — it reads a descriptor the compiled module informs at build time: NAMED_EXTERNREF, a character count, then one u32 per character. tsify supplies that through a single #[wasm_bindgen] extern "C" { type JsType; } per derive, named after the declaration's id.

That extern type is not generic. One Foo<T> derive means one JsType and one fixed name, "Foo", shared by every instantiation. There was nowhere for i64 to go.

# The fix
A new trait, tsify::TsName, composes the name once per monomorphization: the derive unrolls the characters of the type's own declared name and defers to each argument's own impl. Being structural, nesting composes for free, and Ts<T>, Vec<T> and the wasm_abi impls all describe themselves through it. Your example now emits export function bar(foo: Foo<number>): void;.

Every character must arrive as a compile-time constant — wasm-bindgen interprets descriptors with linear memory mirrored but data segments never loaded, so reading a &'static str at describe time would inform a run of NULs. Hence unrolled inform_char calls and a const length.

The name follows the declaration, not the Rust type: #[tsify(rename)] renames both, a parameter no field mentions stays out of the name, and lifetimes and const parameters never appear.

# Breaking changes
A type argument now needs a name of its own. Derived types have one, as do the built-ins tsify implements TsName for — numbers, strings, bool, sequences, HashMap, Option, (), arrays, and the wrappers serde sees through. Anything else is a compile error where the type crosses the ABI, with a #[diagnostic::on_unimplemented] naming the fix: derive Tsify, or one tsify::ts_name!(Foo => 'F', 'o', 'o'); line. Tuples, Result, Duration, Range and non-default hashers are not covered yet — worth a follow-up, since the derive already declares them.
Hand-written impl Tsify needs a TsName impl before Ts<T> accepts it.
Downstream TypeScript can newly fail to type-check. A bare Foo was a TS2314, so anyone hit by this was building with skipLibCheck against an error type behaving like any. Those call sites are now really typed.
Rust 1.78 is now the floor, from #[diagnostic::on_unimplemented]. The crate declares no MSRV; happy to drop it.
DECL took no new bound. Non-generic types describe themselves byte-for-byte as before — all seven existing e2e reference outputs are unchanged.

# Testing
tests-e2e/test7 builds real wasm and reads back the emitted .d.ts — the only place the characters can be checked, since informing them needs the descriptor import that exists only in a wasm build. It covers argument and return position, nesting, built-in and multi-parameter arguments, a generic enum, a skipped parameter, and Ts<T>. On the pre-change code it produces 9 TS2314 errors under tsc --strict; on this branch it is clean, in both profiles. tests/name.rs pins NAME_LEN natively, since a length disagreeing with its characters corrupts the rest of the descriptor rather than announcing itself.

## Resolves
This resolves issue https://github.com/madonoharu/tsify/issues/76

# Disclaimer
This PR was created entirely by claude