### PR TITLE
Pin what a generic type is called across the wasm ABI

### DIFF
--- a/tests-e2e/reference_output/test_generic_args1/test_generic_args1.d.ts
+++ b/tests-e2e/reference_output/test_generic_args1/test_generic_args1.d.ts
@@ -1,0 +1,55 @@
+/* tslint:disable */
+/* eslint-disable */
+export interface AbiEnvelope<T> {
+    data: T;
+}
+
+export interface Arrays {
+    small: [number, number];
+    big: number[];
+}
+
+export interface Defaulted {
+    opt: number | null;
+    map: Record<string, number>;
+    big: number;
+}
+
+export interface Envelope<T> {
+    data: T;
+}
+
+export interface Payload {
+    name: string;
+}
+
+
+export function abi_roundtrip(v: AbiEnvelope): AbiEnvelope;
+
+export function arg_array_big(v: Envelope): void;
+
+export function arg_array_small(v: Envelope): void;
+
+export function arg_map(v: Envelope): void;
+
+export function arg_option(v: Envelope): void;
+
+export function arg_result(v: Envelope): void;
+
+export function arg_tuple(v: Envelope): void;
+
+export function arg_u64(v: Envelope): void;
+
+export function arg_vec(v: Envelope): void;
+
+export function generic_arg(v: Envelope): void;
+
+export function generic_builtin(v: Envelope): void;
+
+export function generic_nested(v: Envelope): void;
+
+export function generic_return(v: Envelope): Envelope;
+
+export function plain_arg(v: Payload): void;
+
+export function plain_return(v: Payload): Payload;

--- a/tests-e2e/reference_output/test_generic_args_js1/test_generic_args_js1.d.ts
+++ b/tests-e2e/reference_output/test_generic_args_js1/test_generic_args_js1.d.ts
@@ -1,0 +1,71 @@
+/* tslint:disable */
+/* eslint-disable */
+export interface AbiEnvelope<T> {
+    data: T;
+}
+
+export interface Arrays {
+    small: [number, number];
+    big: number[];
+}
+
+export interface Configured {
+    opt: number | null;
+    map: Record<string, number>;
+    big: bigint;
+}
+
+export interface ConfiguredEnvelope<T> {
+    data: T;
+}
+
+export interface Defaulted {
+    opt: number | undefined;
+    map: Map<string, number>;
+    big: number;
+}
+
+export interface Envelope<T> {
+    data: T;
+}
+
+export interface Payload {
+    name: string;
+}
+
+
+export function abi_roundtrip(v: AbiEnvelope): AbiEnvelope;
+
+export function arg_array_big(v: Envelope): void;
+
+export function arg_array_small(v: Envelope): void;
+
+export function arg_map(v: Envelope): void;
+
+export function arg_option(v: Envelope): void;
+
+export function arg_result(v: Envelope): void;
+
+export function arg_tuple(v: Envelope): void;
+
+export function arg_u64(v: Envelope): void;
+
+export function arg_vec(v: Envelope): void;
+
+export function configured_map(v: ConfiguredEnvelope): void;
+
+export function configured_option(v: ConfiguredEnvelope): void;
+
+export function configured_u64(v: ConfiguredEnvelope): void;
+
+export function generic_arg(v: Envelope): void;
+
+export function generic_builtin(v: Envelope): void;
+
+export function generic_nested(v: Envelope): void;
+
+export function generic_return(v: Envelope): Envelope;
+
+export function plain_arg(v: Payload): void;
+
+export function plain_return(v: Payload): Payload;

--- a/tests-e2e/test_generic_args1/Cargo.toml
+++ b/tests-e2e/test_generic_args1/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "test_generic_args1"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+# `test_generic_args_js1` shares this crate's `entry_point.rs` and turns this
+# on. Declared here as well so the `cfg` in the shared source is known to both.
+[features]
+js = ["tsify/js"]
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"

--- a/tests-e2e/test_generic_args1/entry_point.rs
+++ b/tests-e2e/test_generic_args1/entry_point.rs
@@ -1,0 +1,184 @@
+#![allow(deprecated, dead_code)]
+
+// This file is built twice: here with the default features, and by
+// `test_generic_args_js1`, which points its `[lib] path` at it and turns on
+// `js`. The pair of reference outputs is what that feature changes.
+//
+// A declaration and the name a type goes by in a signature come from two
+// different places — a `typescript_custom_section` and the descriptor the
+// module informs — and nothing compares them. The reference output is where
+// they can be read together.
+//
+// Both references record #76: a generic reaches a signature without its
+// arguments, so `Envelope` stands where `Envelope<Payload>` is meant. Those
+// lines should change when it is fixed. What should hold either way is that a
+// signature agrees with the declaration of the type it names.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tsify::Ts;
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Envelope<T> {
+    pub data: T,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Payload {
+    pub name: String,
+}
+
+// A non-generic control: nothing to lose, so these two are correct today.
+#[wasm_bindgen]
+pub fn plain_arg(v: Ts<Payload>) -> Result<(), JsError> {
+    let _: Payload = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn plain_return(v: Ts<Payload>) -> Result<Ts<Payload>, JsError> {
+    Ok(v)
+}
+
+#[wasm_bindgen]
+pub fn generic_arg(v: Ts<Envelope<Payload>>) -> Result<(), JsError> {
+    let _: Envelope<Payload> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn generic_return(v: Ts<Envelope<Payload>>) -> Result<Ts<Envelope<Payload>>, JsError> {
+    Ok(v)
+}
+
+#[wasm_bindgen]
+pub fn generic_nested(v: Ts<Envelope<Envelope<Payload>>>) -> Result<(), JsError> {
+    let _: Envelope<Envelope<Payload>> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn generic_builtin(v: Ts<Envelope<u32>>) -> Result<(), JsError> {
+    let _: Envelope<u32> = v.to_rust()?;
+    Ok(())
+}
+
+// The deprecated attributes reach the descriptor by their own route.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct AbiEnvelope<T> {
+    pub data: T,
+}
+
+#[wasm_bindgen]
+pub fn abi_roundtrip(v: AbiEnvelope<u32>) -> AbiEnvelope<u32> {
+    v
+}
+
+// Type arguments the declaration path already renders. They compile today, and
+// are here to keep compiling: requiring every type argument to carry a name of
+// its own would break the build rather than change the reference.
+#[wasm_bindgen]
+pub fn arg_result(v: Ts<Envelope<Result<u32, String>>>) -> Result<(), JsError> {
+    let _: Envelope<Result<u32, String>> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn arg_tuple(v: Ts<Envelope<(u32, String)>>) -> Result<(), JsError> {
+    let _: Envelope<(u32, String)> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn arg_vec(v: Ts<Envelope<Vec<u32>>>) -> Result<(), JsError> {
+    let _: Envelope<Vec<u32>> = v.to_rust()?;
+    Ok(())
+}
+
+// The three types the `js` attributes below rename, with no attribute on them.
+#[wasm_bindgen]
+pub fn arg_option(v: Ts<Envelope<Option<u32>>>) -> Result<(), JsError> {
+    let _: Envelope<Option<u32>> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn arg_map(v: Ts<Envelope<HashMap<String, u32>>>) -> Result<(), JsError> {
+    let _: Envelope<HashMap<String, u32>> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn arg_u64(v: Ts<Envelope<u64>>) -> Result<(), JsError> {
+    let _: Envelope<u64> = v.to_rust()?;
+    Ok(())
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Defaulted {
+    pub opt: Option<u32>,
+    pub map: HashMap<String, u32>,
+    pub big: u64,
+}
+
+// The declaration path splits fixed-size arrays at length 16.
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Arrays {
+    pub small: [u32; 2],
+    pub big: [u32; 20],
+}
+
+#[wasm_bindgen]
+pub fn arg_array_small(v: Ts<Envelope<[u32; 2]>>) -> Result<(), JsError> {
+    let _: Envelope<[u32; 2]> = v.to_rust()?;
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn arg_array_big(v: Ts<Envelope<[u32; 20]>>) -> Result<(), JsError> {
+    let _: Envelope<[u32; 20]> = v.to_rust()?;
+    Ok(())
+}
+
+// These three attributes are rejected without `js`, and are set per container
+// rather than per crate. `Defaulted` and the `arg_option` / `arg_map` /
+// `arg_u64` signatures above are the rows to read each of them against.
+#[cfg(feature = "js")]
+mod configured {
+    use super::*;
+
+    #[derive(Tsify, Serialize, Deserialize)]
+    #[tsify(missing_as_null, hashmap_as_object, large_number_types_as_bigints)]
+    pub struct Configured {
+        pub opt: Option<u32>,
+        pub map: HashMap<String, u32>,
+        pub big: u64,
+    }
+
+    #[derive(Tsify, Serialize, Deserialize)]
+    #[tsify(missing_as_null, hashmap_as_object, large_number_types_as_bigints)]
+    pub struct ConfiguredEnvelope<T> {
+        pub data: T,
+    }
+
+    #[wasm_bindgen]
+    pub fn configured_option(v: Ts<ConfiguredEnvelope<Option<u32>>>) -> Result<(), JsError> {
+        let _: ConfiguredEnvelope<Option<u32>> = v.to_rust()?;
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn configured_map(v: Ts<ConfiguredEnvelope<HashMap<String, u32>>>) -> Result<(), JsError> {
+        let _: ConfiguredEnvelope<HashMap<String, u32>> = v.to_rust()?;
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn configured_u64(v: Ts<ConfiguredEnvelope<u64>>) -> Result<(), JsError> {
+        let _: ConfiguredEnvelope<u64> = v.to_rust()?;
+        Ok(())
+    }
+}

--- a/tests-e2e/test_generic_args_js1/Cargo.toml
+++ b/tests-e2e/test_generic_args_js1/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "test_generic_args_js1"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+# The same source as `test_generic_args1`, built with `js` instead. The pair of
+# reference outputs is what that feature changes.
+[features]
+default = ["js"]
+js = ["tsify/js"]
+
+[lib]
+path = "../test_generic_args1/entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"


### PR DESCRIPTION
## Summary

A declaration and the name a type goes by in a signature are produced by two different paths. The declaration is written into a `typescript_custom_section`; the signature comes from the descriptor the module informs at build time. Nothing compares them, so a disagreement between the two is invisible until someone reads the generated `.d.ts`.

`tests-e2e` is the only place both appear in one file. This adds a crate that puts the pairs next to each other, and a second crate that builds the same source with `js`.

Both references record the current output, which means they record [#76](https://github.com/madonoharu/tsify/issues/76): a generic type reaches a signature without its arguments. When that is fixed, these files change, and the diff is the review.

## One source, two builds

`test_generic_args_js1` has no `entry_point.rs` of its own. It points `[lib] path` at `test_generic_args1`'s and enables `js`, so every case below is pinned under both features and the pair of references is what the feature changes. Today they differ by `Defaulted`:

```ts
// test_generic_args1                  // test_generic_args_js1
opt: number | null;                    opt: number | undefined;
map: Record<string, number>;           map: Map<string, number>;
```

Both manifests declare the `js` feature so the `cfg` in the shared source is known to each; only the second turns it on.

This is the first end-to-end coverage the `js` path has had.

## What the cases cover

- A generic in argument and return position through `Ts<T>`, nested one level, and with a built-in as the argument.
- The same through the deprecated `into_wasm_abi` / `from_wasm_abi` attributes, which reach the descriptor by their own route.
- A non-generic control, whose signature is correct today and must stay correct.
- `Arrays` pins the split the declaration path makes at length 16 — `[u32; 2]` is a tuple, `[u32; 20]` is a sequence — with the same two types in argument position.
- `missing_as_null`, `hashmap_as_object` and `large_number_types_as_bigints`, which are rejected without `js` and are set per container rather than per crate. `Configured` carries all three; `Defaulted` and the `arg_option` / `arg_map` / `arg_u64` signatures are the rows to read each against.
- `Result`, a tuple, `Option`, `HashMap` and `Vec` as type arguments. These compile today, and are here to keep compiling: a change that requires every type argument to carry a name of its own would break the build rather than change a reference.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all`, `cargo test --all -F js`, `./tests-e2e/build_all.sh`, `./tests-e2e/reference_output/compare_output.sh` — all clean. The references are byte-for-byte what `wasm-pack build` emits from this tree.

ref #76
