### PR TITLE
Check the README quickstart's .d.ts against what tsify emits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,29 @@ Two consequences:
    snapshots that pass locally but fail in CI. `cargo metadata --locked`
    will *not* warn — the stale version still satisfies the manifest ranges.
 
+## End-to-end references (`tests-e2e/reference_output/`)
+
+Each crate under `tests-e2e/` is built with `wasm-pack` and the `.d.ts` it emits
+is compared against a committed reference. When your change alters that output
+on purpose, build and then bless it:
+
+```sh
+./tests-e2e/build_all.sh
+./tests-e2e/reference_output/update_output.sh
+git diff
+```
+
+The script writes whatever is in `pkg/` over the references, so build first — it
+cannot tell a stale artifact from a current one. Read the diff before committing
+it; that diff is the review of your change to the generated TypeScript.
+
+One of those references is in the README. `tests-e2e/test_readme_quickstart1`
+builds the README's quickstart itself — its `build.rs` extracts the Rust block
+the README prints — and its reference is the `.d.ts` printed beneath that block,
+which `update_output.sh` rewrites along with the rest. So an intended change to
+the generated TypeScript updates the documentation in the same commit, and an
+unintended one fails the Test job.
+
 ## Why `Cargo.lock` is not committed
 
 Keeping the lockfile out of version control means CI always resolves

--- a/tests-e2e/README.md
+++ b/tests-e2e/README.md
@@ -4,3 +4,12 @@ These tests test the actual `.d.ts` file output by `wasm-pack`. When `wasm-pack 
 on a project in one of the sub-folders, a `pkg/` directory will be created. Running `./reference_output/compare_output.sh`
 will compare the reference output (stored in a directory match the test name) to that generated in the `pkg/` directory
 output by `wasm-pack`.
+
+When the change of output is one you meant to make, `./reference_output/update_output.sh` writes what
+was built over the references, the way `MACROTEST=overwrite` blesses the expansion snapshots. Build
+first — it blesses whatever is in `pkg/`, including a stale one — and then read the `git diff`.
+
+`test_readme_quickstart1` is the README's quickstart rather than a copy of it: its `build.rs` extracts
+the Rust block the README prints and the crate includes that. Its reference is the `.d.ts` the README
+prints underneath, so a change of output shows up as a diff in the documentation, and
+`update_output.sh` writes that block too ([#114](https://github.com/madonoharu/tsify/issues/114)).

--- a/tests-e2e/reference_output/test_readme_quickstart1/test_readme_quickstart1.d.ts
+++ b/tests-e2e/reference_output/test_readme_quickstart1/test_readme_quickstart1.d.ts
@@ -1,0 +1,11 @@
+/* tslint:disable */
+/* eslint-disable */
+export interface Point {
+    x: number;
+    y: number;
+}
+
+
+export function from_js(point: Point): void;
+
+export function into_js(): Point;

--- a/tests-e2e/reference_output/update_output.sh
+++ b/tests-e2e/reference_output/update_output.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# The inverse of compare_output.sh: writes what `wasm-pack build` last emitted
+# over the references, and then over the one block of the README that is a
+# reference too (see ../test_readme_quickstart1).
+#
+# It blesses whatever is in `pkg/` — like `MACROTEST=overwrite` for the
+# expansion snapshots, it is for a change of output you meant to make. Build
+# first, or it blesses a stale artifact:
+#
+#     ./tests-e2e/build_all.sh
+#     ./tests-e2e/reference_output/update_output.sh
+#     git diff
+#
+# It walks the references rather than `pkg/`, so it updates the files already
+# kept here and does not start tracking new ones.
+#
+# One test can be named, so that a change to a single example does not ask for
+# every crate to have been built:
+#
+#     ./tests-e2e/reference_output/update_output.sh test_readme_quickstart1
+
+set -e
+
+cd "$(dirname "$0")" || exit 1
+
+TARGET="${1:-}"
+if [ -n "$TARGET" ] && [ ! -d "./$TARGET" ]; then
+    echo "No reference directory ./$TARGET"
+    echo "   the directories here are:"
+    find . -maxdepth 1 -type d ! -name . -exec basename {} \;
+    exit 1
+fi
+
+README="../../README.md"
+QUICKSTART_REFERENCE="test_readme_quickstart1/test_readme_quickstart1.d.ts"
+# The line the README prints the quickstart's `.d.ts` under.
+ANCHOR='Will generate the following `.d.ts` file:'
+
+for FOLDERNAME in $(find . -maxdepth 1 -type d); do
+    if [ "$FOLDERNAME" = "." ]; then
+        continue
+    fi
+
+    FOLDERNAME="${FOLDERNAME#./}"
+
+    if [ -n "$TARGET" ] && [ "$FOLDERNAME" != "$TARGET" ]; then
+        continue
+    fi
+
+    FILES=$(find "./${FOLDERNAME}/" -type f)
+    for FILE in $FILES; do
+        RELATIVE_PATH="${FILE#./${FOLDERNAME}/}"
+        GENERATED="../${FOLDERNAME}/pkg/${RELATIVE_PATH}"
+
+        # A reference with nothing to update from means the build did not run,
+        # or stopped emitting the file. Blessing the rest would hide that.
+        if [ ! -f "$GENERATED" ]; then
+            echo "Missing generated file: $GENERATED"
+            echo "   run ./tests-e2e/build_all.sh first"
+            exit 1
+        fi
+
+        if cmp -s "$GENERATED" "$FILE"; then
+            echo "Unchanged $FILE"
+        else
+            cp "$GENERATED" "$FILE"
+            echo "Updated   $FILE"
+        fi
+    done
+done
+
+# The README prints the quickstart's `.d.ts` in full, so the block and the
+# reference are the same text. tests/matches_readme.rs is what fails when they
+# stop being.
+if [ -n "$TARGET" ] && [ "$TARGET" != "test_readme_quickstart1" ]; then
+    exit 0
+fi
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+
+awk -v ref="$QUICKSTART_REFERENCE" -v anchor="$ANCHOR" '
+    BEGIN {
+        while ((getline line < ref) > 0) block = block line "\n"
+        close(ref)
+        state = 0
+    }
+    state == 0 { print; if ($0 == anchor) state = 1; next }
+    state == 1 { print; if ($0 == "```ts") { printf "%s", block; state = 2 } next }
+    state == 2 { if ($0 == "```") { print; state = 3 } next }
+    { print }
+    END {
+        if (state != 3) {
+            print "could not find the `ts` block after " anchor > "/dev/stderr"
+            exit 1
+        }
+    }
+' "$README" > "$TMP"
+
+if cmp -s "$TMP" "$README"; then
+    echo "Unchanged $README"
+else
+    cp "$TMP" "$README"
+    echo "Updated   $README"
+fi

--- a/tests-e2e/test_readme_quickstart1/Cargo.toml
+++ b/tests-e2e/test_readme_quickstart1/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "test_readme_quickstart1"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+# The dependencies the README's own Cargo.toml block lists, with `tsify`
+# pointed at this checkout instead of a released version.
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+# No `[build-dependencies]`. The other crates here declare `wasm-bindgen-cli`
+# and have no build script, so nothing compiles it; this one has a build script,
+# which would drag the whole CLI in to read one Markdown block.

--- a/tests-e2e/test_readme_quickstart1/build.rs
+++ b/tests-e2e/test_readme_quickstart1/build.rs
@@ -1,0 +1,27 @@
+//! Extracts the README's quickstart so that the crate builds the example
+//! itself rather than a copy of it.
+//!
+//! A copy would need something to keep it honest; the example having one home
+//! needs nothing. It also keeps the README out of reach of `cargo fmt --check`,
+//! which would otherwise decide the order of the imports a reader sees.
+//!
+//! The block is taken verbatim, so if the quickstart ever starts hiding lines
+//! from the doctest with `# `, this wants a rule for stripping them. It fails
+//! the build rather than going quiet: an anchor that moves panics here.
+
+use std::{env, fs, path::Path};
+
+include!("readme_block.rs");
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let readme = Path::new(&manifest_dir).join("../../README.md");
+    println!("cargo:rerun-if-changed={}", readme.display());
+    println!("cargo:rerun-if-changed=readme_block.rs");
+
+    let text = fs::read_to_string(&readme).unwrap_or_else(|e| panic!("{}: {e}", readme.display()));
+    let block = fenced_block_after(&text, "## Example", "rust");
+
+    let out = Path::new(&env::var("OUT_DIR").expect("OUT_DIR")).join("readme_quickstart.rs");
+    fs::write(&out, block).unwrap_or_else(|e| panic!("{}: {e}", out.display()));
+}

--- a/tests-e2e/test_readme_quickstart1/entry_point.rs
+++ b/tests-e2e/test_readme_quickstart1/entry_point.rs
@@ -1,0 +1,17 @@
+// The README's quickstart, built as itself rather than as a copy.
+//
+// `build.rs` extracts the Rust block printed under `## Example` into `OUT_DIR`
+// and this file includes it, so the example has exactly one home and the crate
+// cannot build from anything else. What is left to check is the other half:
+// the `.d.ts` printed beneath that block, which nothing verified (#114).
+//
+// The harness diffs what this crate emits against `reference_output/`, and
+// `tests/matches_readme.rs` holds that reference to the text the README
+// prints. To bless an intended change of output:
+//
+//     ./tests-e2e/build_all.sh
+//     ./tests-e2e/reference_output/update_output.sh
+
+#![allow(unused_variables)]
+
+include!(concat!(env!("OUT_DIR"), "/readme_quickstart.rs"));

--- a/tests-e2e/test_readme_quickstart1/readme_block.rs
+++ b/tests-e2e/test_readme_quickstart1/readme_block.rs
@@ -1,0 +1,25 @@
+// Shared by `build.rs`, which extracts the README's Rust block so that this
+// crate builds the example itself, and by `tests/matches_readme.rs`, which
+// extracts the TypeScript block printed beneath it. `include!`d rather than
+// imported: a build script and an integration test have no crate in common,
+// and the two must agree on what "the block" means.
+
+/// The body of the first fenced `lang` block that follows the line `anchor`.
+///
+/// `anchor` is matched as a whole line, so a deeper heading ending in the same
+/// words is not mistaken for it, and neither is a mention of it in prose.
+fn fenced_block_after<'a>(text: &'a str, anchor: &str, lang: &str) -> &'a str {
+    let anchor_line = format!("\n{anchor}\n");
+    let after_anchor = text
+        .split_once(anchor_line.as_str())
+        .unwrap_or_else(|| panic!("the README no longer has a line {anchor:?}"))
+        .1;
+    let open = format!("```{lang}\n");
+    let body = after_anchor
+        .split_once(open.as_str())
+        .unwrap_or_else(|| panic!("no `{lang}` block after {anchor:?} in the README"))
+        .1;
+    body.split_once("```")
+        .unwrap_or_else(|| panic!("unterminated `{lang}` block after {anchor:?} in the README"))
+        .0
+}

--- a/tests-e2e/test_readme_quickstart1/tests/matches_readme.rs
+++ b/tests-e2e/test_readme_quickstart1/tests/matches_readme.rs
@@ -1,0 +1,39 @@
+//! Holds the reference `.d.ts` to the text the README prints.
+//!
+//! The harness compares that reference against what `wasm-pack build` emits
+//! from this crate, and the crate is the README's own Rust block by
+//! construction. This is the remaining link: that the block the README prints
+//! is the reference being compared, rather than some other text that once
+//! resembled it.
+//!
+//! The paths are `include_str!`s, so a file that moves is a build error rather
+//! than a check that quietly stops checking anything.
+
+const README: &str = include_str!("../../../README.md");
+const REFERENCE: &str =
+    include_str!("../../reference_output/test_readme_quickstart1/test_readme_quickstart1.d.ts");
+
+include!("../readme_block.rs");
+
+#[test]
+fn an_anchor_is_a_whole_line() {
+    let text = "\n### Example\n\n```rust\nwrong\n```\n\n## Example\n\n```rust\nright\n```\n";
+    assert_eq!(fenced_block_after(text, "## Example", "rust"), "right\n");
+}
+
+#[test]
+fn a_fence_of_another_language_is_not_the_block() {
+    let text = "\n## Example\n\n```toml\nwrong\n```\n\n```rust\nright\n```\n";
+    assert_eq!(fenced_block_after(text, "## Example", "rust"), "right\n");
+}
+
+#[test]
+fn reference_output_is_what_the_readme_prints() {
+    assert_eq!(
+        fenced_block_after(README, "Will generate the following `.d.ts` file:", "ts"),
+        REFERENCE,
+        "the `.d.ts` the README prints and the reference this crate is compared \
+         against have diverged; `./tests-e2e/reference_output/update_output.sh` \
+         writes the emitted output over both"
+    );
+}


### PR DESCRIPTION
## Summary

The README is the crate documentation through `include_str!`, so every `rust` block in it is a doctest and gets compiled on each CI run. The `.d.ts` printed underneath — the part a reader actually came for — is plain text. For a derive crate the output *is* the product, so a stale example is a wrong answer rather than a cosmetic slip.

This pins the quickstart, the example most likely to be read.

`tests-e2e/test_readme_quickstart1` does not hold a copy of that example. Its `build.rs` extracts the Rust block the README prints and the crate `include!`s it, so the example has exactly one home and the crate cannot build from anything else. Its reference output is the `.d.ts` the README prints underneath, and the existing harness compares that against what `wasm-pack build` emits — on stable, with no flag, on every PR: `./test.sh` runs `build_all.sh` and `compare_output.sh`, and the Test job runs `./test.sh`.

The block agrees with the current output byte for byte, so nothing in the documentation is wrong today. From here, a change that makes them disagree fails.

## Why this is not hypothetical

[#106](https://github.com/madonoharu/tsify/pull/106) rewrote the quickstart and I reverted that part while merging it. The revert dropped one blank line from the block the README prints, which no longer matched what `wasm-pack` emits. Nothing in the repository caught it — I found it by diffing against `main` by hand, on the way to opening this. That is the whole argument for the check, made by the change that removed it.

## Blessing an intended change

`reference_output/update_output.sh` is the inverse of `compare_output.sh`: it writes what was built over the references, and over the block of the README that is one of them.

```sh
./tests-e2e/build_all.sh
./tests-e2e/reference_output/update_output.sh
git diff
```

That is the shape this repository already uses for the expansion snapshots — a committed artifact, compared on every PR, with `MACROTEST=overwrite` as the way to update it. A deliberate change to the generated TypeScript now updates the documentation in the same commit, and the diff is the review.

It takes one test name — `update_output.sh test_readme_quickstart1` — so a change to a single example does not ask for every crate to have been built. It walks the references rather than `pkg/`, so it updates the files already kept and does not start tracking new ones; a reference with no build behind it is an error rather than a silent skip.

Round trip, measured on this branch: adding a field to the README's `Point` changed the emitted `.d.ts`, `compare_output.sh` failed on the difference, and `update_output.sh` brought the reference and the README block back into agreement.

## What is left to assert

`tests/matches_readme.rs` holds the reference to the text the README prints. The Rust half needs no assertion — it is the same text by construction — but the TypeScript half is two files meant to say the same thing, and that is the one link left to state. Both paths are `include_str!`s, so a file that moves is a build error rather than a check that quietly stops checking anything.

The extractor is shared by `build.rs` and the test through `include!`, so they cannot disagree about what "the block" is, and it matches an anchor as a whole line: `### Example` is not `## Example`, and a `toml` fence in the way is not the `rust` one. Two unit tests hold it to that.

## Two things worth flagging in review

The crate declares no `[build-dependencies]`. The other e2e crates list `wasm-bindgen-cli` and have no build script, so nothing compiles it; with a build script present, that entry pulls the whole CLI in — walrus and the rest — to read one Markdown block.

The block is taken verbatim, so if the quickstart ever starts hiding lines from the doctest with `# `, `build.rs` wants a rule for stripping them. It fails loudly either way: an anchor that moves panics the build script.

## What this does not do

No `tsc --strict --noEmit` gate. `test_generic_args1`'s reference deliberately records the wrong output of [#76](https://github.com/madonoharu/tsify/issues/76) — a generic reaching a signature without its type arguments — so type-checking the e2e output would fail on a case that is recorded on purpose. That gate belongs after #76 is fixed.

This covers one example rather than all six. The general mechanism — enumerating every doctest through rustdoc's JSON and generating a crate per doctest — is what @feefladder built in #106; identifying the gap and the working prototype are theirs. It needs nightly today, which is why [#114](https://github.com/madonoharu/tsify/issues/114) stays open for it.

## Checks

`cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings`, and `./test.sh` — all clean on this tree, rebased onto `main` after #106. `./test.sh` covers `cargo test --all`, `cargo test --all -F js`, `wasm-pack test --node` under both, and the e2e build and comparison. The reference is byte-for-byte what `wasm-pack build` emits here, and `README.md` is unchanged by this PR.

ref #114
