### PR TITLE
Keep the README block search inside the section it was anchored to

### DIFF
--- a/tests-e2e/reference_output/update_output.sh
+++ b/tests-e2e/reference_output/update_output.sh
@@ -1,24 +1,18 @@
 #!/bin/bash
 
 # The inverse of compare_output.sh: writes what `wasm-pack build` last emitted
-# over the references, and then over the one block of the README that is a
-# reference too (see ../test_readme_quickstart1).
-#
-# It blesses whatever is in `pkg/` — like `MACROTEST=overwrite` for the
-# expansion snapshots, it is for a change of output you meant to make. Build
-# first, or it blesses a stale artifact:
+# over the references, and over the one block of the README that is a reference
+# too (see ../test_readme_quickstart1). It blesses whatever is in `pkg/`, so
+# build first.
 #
 #     ./tests-e2e/build_all.sh
-#     ./tests-e2e/reference_output/update_output.sh
+#     ./tests-e2e/reference_output/update_output.sh [test_name]
 #     git diff
 #
-# It walks the references rather than `pkg/`, so it updates the files already
-# kept here and does not start tracking new ones.
-#
-# One test can be named, so that a change to a single example does not ask for
-# every crate to have been built:
-#
-#     ./tests-e2e/reference_output/update_output.sh test_readme_quickstart1
+# It walks the references rather than `pkg/`, so it updates what is already kept
+# here and does not start tracking new files. Nothing is written until
+# everything has been read, or a README it cannot parse would leave the
+# references updated and the README not.
 
 set -e
 
@@ -33,74 +27,100 @@ if [ -n "$TARGET" ] && [ ! -d "./$TARGET" ]; then
 fi
 
 README="../../README.md"
-QUICKSTART_REFERENCE="test_readme_quickstart1/test_readme_quickstart1.d.ts"
+QUICKSTART="test_readme_quickstart1"
+QUICKSTART_GENERATED="../${QUICKSTART}/pkg/${QUICKSTART}.d.ts"
 # The line the README prints the quickstart's `.d.ts` under.
 ANCHOR='Will generate the following `.d.ts` file:'
 
-for FOLDERNAME in $(find . -maxdepth 1 -type d); do
-    if [ "$FOLDERNAME" = "." ]; then
-        continue
-    fi
-
-    FOLDERNAME="${FOLDERNAME#./}"
-
-    if [ -n "$TARGET" ] && [ "$FOLDERNAME" != "$TARGET" ]; then
-        continue
-    fi
-
-    FILES=$(find "./${FOLDERNAME}/" -type f)
-    for FILE in $FILES; do
-        RELATIVE_PATH="${FILE#./${FOLDERNAME}/}"
-        GENERATED="../${FOLDERNAME}/pkg/${RELATIVE_PATH}"
-
-        # A reference with nothing to update from means the build did not run,
-        # or stopped emitting the file. Blessing the rest would hide that.
-        if [ ! -f "$GENERATED" ]; then
-            echo "Missing generated file: $GENERATED"
-            echo "   run ./tests-e2e/build_all.sh first"
-            exit 1
+# The set of reference files to update, as `<reference>\t<generated>` lines.
+# `find` is the same walk compare_output.sh makes, so the two stay in step.
+pairs() {
+    for FOLDERNAME in $(find . -maxdepth 1 -type d); do
+        if [ "$FOLDERNAME" = "." ]; then
+            continue
         fi
-
-        if cmp -s "$GENERATED" "$FILE"; then
-            echo "Unchanged $FILE"
-        else
-            cp "$GENERATED" "$FILE"
-            echo "Updated   $FILE"
+        FOLDERNAME="${FOLDERNAME#./}"
+        if [ -n "$TARGET" ] && [ "$FOLDERNAME" != "$TARGET" ]; then
+            continue
         fi
+        for FILE in $(find "./${FOLDERNAME}/" -type f); do
+            RELATIVE_PATH="${FILE#./${FOLDERNAME}/}"
+            printf '%s\t%s\n' "$FILE" "../${FOLDERNAME}/pkg/${RELATIVE_PATH}"
+        done
     done
+}
+
+# ── Phase 1: read and validate. No writes. ───────────────────────────────────
+
+PAIRS=$(pairs)
+
+echo "$PAIRS" | while IFS="$(printf '\t')" read -r FILE GENERATED; do
+    [ -n "$FILE" ] || continue
+    # A reference with nothing to update from means the build did not run, or
+    # stopped emitting the file. Blessing the rest would hide that.
+    if [ ! -f "$GENERATED" ]; then
+        echo "Missing generated file: $GENERATED" >&2
+        echo "   run ./tests-e2e/build_all.sh first" >&2
+        exit 1
+    fi
 done
 
-# The README prints the quickstart's `.d.ts` in full, so the block and the
-# reference are the same text. tests/matches_readme.rs is what fails when they
-# stop being.
-if [ -n "$TARGET" ] && [ "$TARGET" != "test_readme_quickstart1" ]; then
-    exit 0
+TMP=""
+if [ -z "$TARGET" ] || [ "$TARGET" = "$QUICKSTART" ]; then
+    # The README prints the quickstart's `.d.ts` in full, so the block and the
+    # reference are the same text, and both come from the same build.
+    # tests/matches_readme.rs is what fails when they stop being.
+    TMP=$(mktemp)
+    trap 'rm -f "$TMP"' EXIT
+
+    awk -v generated="$QUICKSTART_GENERATED" -v anchor="$ANCHOR" '
+        BEGIN {
+            while ((getline line < generated) > 0) block = block line "\n"
+            close(generated)
+            state = 0
+        }
+        state == 0 { print; if ($0 == anchor) state = 1; next }
+        # The block has to belong to the section the anchor is in. Walking past
+        # a heading would rewrite something that belongs to another example —
+        # see the note in ../test_readme_quickstart1/readme_block.rs.
+        state == 1 {
+            if ($0 ~ /^## /) {
+                print "no `ts` block in the README section that follows " anchor > "/dev/stderr"
+                bad = 1
+                exit 1
+            }
+            print
+            if ($0 == "```ts") { printf "%s", block; state = 2 }
+            next
+        }
+        state == 2 { if ($0 == "```") { print; state = 3 } next }
+        { print }
+        END {
+            if (!bad && state != 3) {
+                print "could not find the `ts` block after " anchor > "/dev/stderr"
+                exit 1
+            }
+        }
+    ' "$README" > "$TMP"
 fi
 
-TMP=$(mktemp)
-trap 'rm -f "$TMP"' EXIT
+# ── Phase 2: write. Everything above has already succeeded. ──────────────────
 
-awk -v ref="$QUICKSTART_REFERENCE" -v anchor="$ANCHOR" '
-    BEGIN {
-        while ((getline line < ref) > 0) block = block line "\n"
-        close(ref)
-        state = 0
-    }
-    state == 0 { print; if ($0 == anchor) state = 1; next }
-    state == 1 { print; if ($0 == "```ts") { printf "%s", block; state = 2 } next }
-    state == 2 { if ($0 == "```") { print; state = 3 } next }
-    { print }
-    END {
-        if (state != 3) {
-            print "could not find the `ts` block after " anchor > "/dev/stderr"
-            exit 1
-        }
-    }
-' "$README" > "$TMP"
+echo "$PAIRS" | while IFS="$(printf '\t')" read -r FILE GENERATED; do
+    [ -n "$FILE" ] || continue
+    if cmp -s "$GENERATED" "$FILE"; then
+        echo "Unchanged $FILE"
+    else
+        cp "$GENERATED" "$FILE"
+        echo "Updated   $FILE"
+    fi
+done
 
-if cmp -s "$TMP" "$README"; then
-    echo "Unchanged $README"
-else
-    cp "$TMP" "$README"
-    echo "Updated   $README"
+if [ -n "$TMP" ]; then
+    if cmp -s "$TMP" "$README"; then
+        echo "Unchanged $README"
+    else
+        cp "$TMP" "$README"
+        echo "Updated   $README"
+    fi
 fi

--- a/tests-e2e/test_readme_quickstart1/build.rs
+++ b/tests-e2e/test_readme_quickstart1/build.rs
@@ -1,13 +1,10 @@
-//! Extracts the README's quickstart so that the crate builds the example
-//! itself rather than a copy of it.
+//! Extracts the README's quickstart, so the example has one home instead of a
+//! copy to keep honest. Do not replace this with a checked-in copy: a copy is a
+//! workspace source, so `cargo fmt --all -- --check` would reorder the imports
+//! a reader sees in the README.
 //!
-//! A copy would need something to keep it honest; the example having one home
-//! needs nothing. It also keeps the README out of reach of `cargo fmt --check`,
-//! which would otherwise decide the order of the imports a reader sees.
-//!
-//! The block is taken verbatim, so if the quickstart ever starts hiding lines
-//! from the doctest with `# `, this wants a rule for stripping them. It fails
-//! the build rather than going quiet: an anchor that moves panics here.
+//! The block is taken verbatim: if the quickstart ever hides lines from the
+//! doctest with `# `, this wants a rule for stripping them.
 
 use std::{env, fs, path::Path};
 

--- a/tests-e2e/test_readme_quickstart1/entry_point.rs
+++ b/tests-e2e/test_readme_quickstart1/entry_point.rs
@@ -1,16 +1,6 @@
-// The README's quickstart, built as itself rather than as a copy.
-//
-// `build.rs` extracts the Rust block printed under `## Example` into `OUT_DIR`
-// and this file includes it, so the example has exactly one home and the crate
-// cannot build from anything else. What is left to check is the other half:
-// the `.d.ts` printed beneath that block, which nothing verified (#114).
-//
-// The harness diffs what this crate emits against `reference_output/`, and
-// `tests/matches_readme.rs` holds that reference to the text the README
-// prints. To bless an intended change of output:
-//
-//     ./tests-e2e/build_all.sh
-//     ./tests-e2e/reference_output/update_output.sh
+// The README's quickstart, built as itself rather than as a copy: `build.rs`
+// extracts the block and this includes it. What the harness then compares is
+// the `.d.ts` printed beneath that block (#114).
 
 #![allow(unused_variables)]
 

--- a/tests-e2e/test_readme_quickstart1/readme_block.rs
+++ b/tests-e2e/test_readme_quickstart1/readme_block.rs
@@ -4,22 +4,36 @@
 // imported: a build script and an integration test have no crate in common,
 // and the two must agree on what "the block" means.
 
-/// The body of the first fenced `lang` block that follows the line `anchor`.
+/// The body of the first fenced `lang` block that follows the line `anchor` and
+/// belongs to the same section as it.
 ///
-/// `anchor` is matched as a whole line, so a deeper heading ending in the same
-/// words is not mistaken for it, and neither is a mention of it in prose.
+/// Both bounds matter. `anchor` is a whole line, so `### Example` is not
+/// `## Example`. The search stops at the next `## ` heading, so renaming a
+/// fence to a language that renders the same — ```` ```ts ```` to
+/// ```` ```typescript ```` — fails here instead of quietly matching a block
+/// in some later section that everything downstream would then agree on.
 fn fenced_block_after<'a>(text: &'a str, anchor: &str, lang: &str) -> &'a str {
     let anchor_line = format!("\n{anchor}\n");
     let after_anchor = text
         .split_once(anchor_line.as_str())
         .unwrap_or_else(|| panic!("the README no longer has a line {anchor:?}"))
         .1;
+    let section = match after_anchor.find("\n## ") {
+        Some(next_heading) => &after_anchor[..next_heading],
+        None => after_anchor,
+    };
     let open = format!("```{lang}\n");
-    let body = after_anchor
+    let body = section
         .split_once(open.as_str())
-        .unwrap_or_else(|| panic!("no `{lang}` block after {anchor:?} in the README"))
+        .unwrap_or_else(|| {
+            panic!("no `{lang}` block in the README section that follows {anchor:?}")
+        })
         .1;
-    body.split_once("```")
-        .unwrap_or_else(|| panic!("unterminated `{lang}` block after {anchor:?} in the README"))
-        .0
+    if body.starts_with("```") {
+        panic!("the `{lang}` block after {anchor:?} in the README is empty");
+    }
+    let end = body
+        .find("\n```")
+        .unwrap_or_else(|| panic!("unterminated `{lang}` block after {anchor:?} in the README"));
+    &body[..end + 1]
 }

--- a/tests-e2e/test_readme_quickstart1/tests/matches_readme.rs
+++ b/tests-e2e/test_readme_quickstart1/tests/matches_readme.rs
@@ -1,13 +1,8 @@
 //! Holds the reference `.d.ts` to the text the README prints.
 //!
-//! The harness compares that reference against what `wasm-pack build` emits
-//! from this crate, and the crate is the README's own Rust block by
-//! construction. This is the remaining link: that the block the README prints
-//! is the reference being compared, rather than some other text that once
-//! resembled it.
-//!
-//! The paths are `include_str!`s, so a file that moves is a build error rather
-//! than a check that quietly stops checking anything.
+//! The harness compares that reference against what `wasm-pack build` emits;
+//! this is the other link, that the reference is still the block the README
+//! prints. `include_str!`, so a file that moves is a build error.
 
 const README: &str = include_str!("../../../README.md");
 const REFERENCE: &str =
@@ -25,6 +20,20 @@ fn an_anchor_is_a_whole_line() {
 fn a_fence_of_another_language_is_not_the_block() {
     let text = "\n## Example\n\n```toml\nwrong\n```\n\n```rust\nright\n```\n";
     assert_eq!(fenced_block_after(text, "## Example", "rust"), "right\n");
+}
+
+#[test]
+#[should_panic(expected = "no `ts` block in the README section")]
+fn a_block_in_a_later_section_is_not_the_block() {
+    let text = "\n## Example\n\n```typescript\nrenamed\n```\n\n## Other\n\n```ts\nelsewhere\n```\n";
+    fenced_block_after(text, "## Example", "ts");
+}
+
+#[test]
+#[should_panic(expected = "is empty")]
+fn an_empty_block_is_rejected() {
+    let text = "\n## Example\n\n```ts\n```\n";
+    fenced_block_after(text, "## Example", "ts");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

[#117](https://github.com/madonoharu/tsify/pull/117) added a check that the `.d.ts` the README prints is what tsify emits. An adversarial review of it found that the check could be walked around without anyone noticing, and I reproduced that before fixing it.

`fenced_block_after` took the first fence of the right language *anywhere* below its anchor. So renaming a fence to a language that renders identically — ` ```ts ` to ` ```typescript ` — did not fail. The search walked past it and settled on the next ` ```ts ` block in the file.

Measured on `main`: with the quickstart's fence renamed, the anchor is found at README:51 and the block selected is at README:131 — the output block of the "Type Override" section. `update_output.sh` rewrites *that* block with the quickstart's `.d.ts`; `tests/matches_readme.rs` then selects the same wrong block and agrees with it; `compare_output.sh` only ever compares the reference against the build. The whole run is green, and an unrelated piece of documentation has been overwritten.

## The rule

A block now has to belong to the section its anchor is in: the search stops at the next `## ` heading.

**Adjacency would have been wrong**, which is worth writing down because it was my first attempt. The quickstart's Rust block is not the first thing after `## Example` — a `<details>` element containing a `toml` fence sits between them. "Immediately after the anchor" fails on this README's own structure; "in the same section" does not.

Two smaller holes in the same function:

- the closing fence was matched as a substring, so a ` ``` ` inside a block would end it early. It is matched at the start of a line now.
- an empty block was returned rather than refused. That is the shape a vacuous pass takes — an empty block, an empty reference and empty output all agree — so it is now an error.

## `update_output.sh` reads before it writes

It copied the references one at a time and only then parsed the README, so a README it could not parse left the references updated and the README not — a partial bless, which is worse than either outcome.

It is now two phases: everything is read and validated first (every reference has a build behind it, the README parses, the new README text is produced), and nothing is written until all of that has succeeded. The README's new text also comes from the build output rather than from the reference the script just wrote, so both sides come from one source.

## Checks

With the quickstart fence renamed to `typescript`:

```
$ ./tests-e2e/reference_output/update_output.sh
no `ts` block in the README section that follows Will generate the following `.d.ts` file:
$ echo $?
1
```

No reference file was modified. `cargo test -p test_readme_quickstart1` fails with the same message. With the README restored, the suite is green again.

`./test.sh`, `cargo fmt --all -- --check` and `cargo clippy --all --all-targets -- -D warnings` are clean. Three unit tests cover the rule: a fence in a later section is refused, an empty block is refused, and a fence of another language *within* the section is still skipped correctly.

## Still open

Two things the review raised that this does not fix, both documented rather than solved: `update_output.sh` will happily bless a stale `pkg/` if you forget to build first, and neither script notices a `.d.ts` in `pkg/` that no reference covers.

ref #114
