### PR TITLE
Stop a mistyped subcommand from starting a release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -268,7 +268,7 @@ cmd_check() {
 
 rewrite() {
     # Every pattern is checked before anything is written. `perl -pi` replaces
-    # first and counts afterwards, so a pattern that stopped matching would
+    # first and counts afterward, so a pattern that stopped matching would
     # otherwise leave the earlier files rewritten and the release half-prepared.
     grep -q '^version = "' Cargo.toml || { echo "error: Cargo.toml has no version line" >&2; exit 1; }
     grep -q '^version = "' tsify-macros/Cargo.toml || { echo "error: tsify-macros/Cargo.toml has no version line" >&2; exit 1; }
@@ -361,7 +361,7 @@ prepare_release() {
             --title "Release $version" \
             --body "Moves both crates to $version, along with the floor \`tsify\` puts on \`tsify-macros\`, the version the README tells people to depend on, and a CHANGELOG heading.
 
-Once this is merged, \`./scripts/release.sh publish $version\` on main uploads both crates." \
+Once this is merged, \`./scripts/release.sh $version\` on main uploads both crates." \
             || note "the pull request could not be opened — open it by hand; the branch is pushed"
     else
         note "gh is not installed — open the pull request by hand"
@@ -370,9 +370,20 @@ Once this is merged, \`./scripts/release.sh publish $version\` on main uploads b
     if [ "$wait_for_merge" = true ] && command -v gh >/dev/null 2>&1; then
         step "Waiting for the pull request to be merged"
         echo "  merge it and this carries on by itself; Ctrl-C is safe"
-        local waited=0 state
+        # Waiting for a person has no useful ceiling, but waiting for `gh` does:
+        # an expired login answers nothing, and nothing is neither MERGED nor
+        # CLOSED, so the loop would run until someone noticed.
+        local waited=0 state unreadable=0
         while :; do
-            state=$(gh pr view "release/$version" --json state --jq .state 2>/dev/null || echo UNKNOWN)
+            if state=$(gh pr view "release/$version" --json state --jq .state 2>/dev/null); then
+                unreadable=0
+            elif [ $((unreadable += 1)) -ge 20 ]; then
+                echo "error: gh could not read the pull request in twenty tries" >&2
+                echo "       the branch is pushed; merge it and run this again" >&2
+                return 1
+            else
+                state=UNKNOWN
+            fi
             case "$state" in
                 MERGED) break ;;
                 CLOSED) echo "error: the pull request was closed without merging" >&2; return 1 ;;
@@ -667,7 +678,17 @@ for arg in "$@"; do
         -w | --wait) wait_for_merge=true ;;
         --allow-dirty) allow_dirty="--allow-dirty" ;;
         -*) echo "error: unknown option $arg" >&2; exit 2 ;;
-        *) version="$arg" ;;
+        # A word that is not a subcommand is the version. Taking a second one
+        # would mean a mistyped `status` silently ran the release instead —
+        # measured: `statsu 0.6.0` used to reach the release path.
+        *)
+            if [ -n "$version" ]; then
+                echo "error: don't know what to do with '$arg'" >&2
+                echo "       the only subcommands are 'status' and 'check'" >&2
+                exit 2
+            fi
+            version="$arg"
+            ;;
     esac
 done
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,7 +13,8 @@
 # It stops for exactly one thing it cannot do: `main` requires a pull request
 # and enforces that on administrators, so the version bump has to be merged by a
 # person. Give it `--wait` and it will sit there until the merge happens and
-# then carry on.
+# then carry on. It gives up only if `gh` itself stops answering for half an
+# hour, which is a broken login rather than a slow reviewer.
 #
 # `tsify` and `tsify-macros` go up as a pair, macro first, and the root has to
 # be published against a floor that already requires the new macro. Getting that
@@ -36,6 +37,8 @@ cd "$(dirname "$0")/.."
 
 api="https://crates.io/api/v1/crates"
 index_timeout_seconds=600
+# How long `gh` may go on saying nothing before --wait stops believing in it.
+gh_silence_seconds=1800
 user_agent="tsify-release-script (+https://github.com/madonoharu/tsify)"
 
 # Set by `-y`. It does not reach the question before publishing.
@@ -372,13 +375,15 @@ Once this is merged, \`./scripts/release.sh $version\` on main uploads both crat
         echo "  merge it and this carries on by itself; Ctrl-C is safe"
         # Waiting for a person has no useful ceiling, but waiting for `gh` does:
         # an expired login answers nothing, and nothing is neither MERGED nor
-        # CLOSED, so the loop would run until someone noticed.
-        local waited=0 state unreadable=0
+        # CLOSED, so the loop would run until someone noticed. Counted in
+        # seconds rather than tries, so the message says something a reader can
+        # check, and long enough that a network blip is not mistaken for it.
+        local waited=0 state silent=0
         while :; do
             if state=$(gh pr view "release/$version" --json state --jq .state 2>/dev/null); then
-                unreadable=0
-            elif [ $((unreadable += 1)) -ge 20 ]; then
-                echo "error: gh could not read the pull request in twenty tries" >&2
+                silent=0
+            elif [ "$silent" -ge "$gh_silence_seconds" ]; then
+                echo "error: gh has not answered for ${silent}s" >&2
                 echo "       the branch is pushed; merge it and run this again" >&2
                 return 1
             else
@@ -390,6 +395,7 @@ Once this is merged, \`./scripts/release.sh $version\` on main uploads both crat
             esac
             sleep 15
             waited=$((waited + 15))
+            [ "$state" = UNKNOWN ] && silent=$((silent + 15))
             [ $((waited % 60)) -eq 0 ] && echo "  ... ${waited}s"
         done
         pass "merged"


### PR DESCRIPTION
`status` and `check` were the only words the argument loop knew as
subcommands. Anything else became the version, and the last one won, so
`./scripts/release.sh statsu 0.6.0` did not fail — it ran the release.
A read-only command one keystroke away from the write path is the wrong
default for a script whose middle step cannot be undone. A second
non-option word is now an error that names the two subcommands there are.

The pull request the script opens told the reader to run
`./scripts/release.sh publish <version>`, which was never a subcommand
either; it worked only through the rule above. Both the instruction and
the accident carrying it are gone.

`--wait` polled `gh` and read every failure as an unknown state, which is
neither MERGED nor CLOSED. An expired login left it sleeping fifteen
seconds at a time with nothing that could wake it. Waiting for a person
still has no ceiling, which is right; waiting for a tool that has stopped
answering now has one.

The comment above `rewrite` used the British spelling of `afterward`, and
this repository writes American English.

## How this was checked

    statsu 0.6.0              error: don't know what to do with '0.6.0'   exit 2
    publish 0.6.0             error: don't know what to do with '0.6.0'   exit 2
    0.6.0 publish             error: don't know what to do with 'publish' exit 2
    status 0.6.0              status,  version=0.6.0                     exit 0
    0.6.0 -y --wait           release, version=0.6.0                     exit 0
    check 0.6.0 --allow-dirty check,   version=0.6.0                     exit 0

The wait loop was lifted out of the file and run against a `gh` that always
fails: it stops after twenty polls rather than sleeping forever, and still
breaks out when `gh` answers MERGED.

One thing that looked like a defect is not one. `published_sha` pipes `curl`
into `tar` into `jq` under `pipefail`, which would be a problem if `tar` exited
as soon as it had the member it wanted and left `curl` writing into a closed
pipe. It does not: a 40MB archive whose target member comes first still leaves
the writer at exit 0, and the pipeline reads the sha out of the published
tsify 0.5.8 without complaint. Left alone.

Not fixed: the window between the check that HEAD is origin/main and the
publish that follows it. Nothing re-reads origin/main in between, so a merge
landing during a release would leave the published version and its tag on the
older commit. That window can be narrowed but not closed, and this repository
has one person releasing a few times a year.

ref #120
