### PR TITLE
Read the README the same way whichever line endings it has

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# The e2e harness reads these as text and compares them byte for byte, and it
+# looks for `\n`. Git checks files out with CRLF wherever `core.autocrlf` is on,
+# which is the default on Windows; without this the README extraction, the
+# reference diff and the bless script all disagree with the files on disk (#121).
+*.md    text eol=lf
+*.rs    text eol=lf
+*.ts    text eol=lf
+*.sh    text eol=lf
+*.toml  text eol=lf

--- a/tests-e2e/test_readme_quickstart1/readme_block.rs
+++ b/tests-e2e/test_readme_quickstart1/readme_block.rs
@@ -4,6 +4,18 @@
 // imported: a build script and an integration test have no crate in common,
 // and the two must agree on what "the block" means.
 
+/// The README with one kind of line ending, so that everything below can look
+/// for `\n`.
+///
+/// Git checks Markdown out with CRLF wherever `core.autocrlf` is on, which is
+/// the default on Windows, and then no search for a whole line matches and the
+/// build script panics saying the anchor is gone (#121). Normalizing here
+/// rather than at each call site is what keeps the extraction and the
+/// comparison agreeing about what the file says.
+fn lf(text: &str) -> String {
+    text.replace("\r\n", "\n")
+}
+
 /// The body of the first fenced `lang` block that follows the line `anchor` and
 /// belongs to the same section as it.
 ///
@@ -12,7 +24,8 @@
 /// fence to a language that renders the same — ```` ```ts ```` to
 /// ```` ```typescript ```` — fails here instead of quietly matching a block
 /// in some later section that everything downstream would then agree on.
-fn fenced_block_after<'a>(text: &'a str, anchor: &str, lang: &str) -> &'a str {
+fn fenced_block_after(text: &str, anchor: &str, lang: &str) -> String {
+    let text = lf(text);
     let anchor_line = format!("\n{anchor}\n");
     let after_anchor = text
         .split_once(anchor_line.as_str())
@@ -35,5 +48,5 @@ fn fenced_block_after<'a>(text: &'a str, anchor: &str, lang: &str) -> &'a str {
     let end = body
         .find("\n```")
         .unwrap_or_else(|| panic!("unterminated `{lang}` block after {anchor:?} in the README"));
-    &body[..end + 1]
+    body[..end + 1].to_string()
 }

--- a/tests-e2e/test_readme_quickstart1/tests/matches_readme.rs
+++ b/tests-e2e/test_readme_quickstart1/tests/matches_readme.rs
@@ -30,6 +30,18 @@ fn a_block_in_a_later_section_is_not_the_block() {
 }
 
 #[test]
+fn a_crlf_checkout_finds_the_same_block() {
+    // What Windows gets by default. Before #121 the anchor search looked for
+    // "\n## Example\n", which a CRLF file never contains, so the build script
+    // panicked saying the README had lost the heading.
+    let lf_text = "\n## Example\n\n```rust\nright\n```\n";
+    assert_eq!(
+        fenced_block_after(&lf_text.replace('\n', "\r\n"), "## Example", "rust"),
+        fenced_block_after(lf_text, "## Example", "rust"),
+    );
+}
+
+#[test]
 #[should_panic(expected = "is empty")]
 fn an_empty_block_is_rejected() {
     let text = "\n## Example\n\n```ts\n```\n";
@@ -40,7 +52,9 @@ fn an_empty_block_is_rejected() {
 fn reference_output_is_what_the_readme_prints() {
     assert_eq!(
         fenced_block_after(README, "Will generate the following `.d.ts` file:", "ts"),
-        REFERENCE,
+        // Both sides through `lf`: on a CRLF checkout these two files differ by
+        // their line endings alone, which is not a divergence worth failing on.
+        lf(REFERENCE),
         "the `.d.ts` the README prints and the reference this crate is compared \
          against have diverged; `./tests-e2e/reference_output/update_output.sh` \
          writes the emitted output over both"


### PR DESCRIPTION
`core.autocrlf` is on by default on Windows, so the README arrives in the
working tree with CRLF, and both halves of the quickstart check search it
for `\n`. The anchor search looks for a whole line — "\n## Example\n" —
which a CRLF file never contains, so the build script panics saying the
README has lost a heading it plainly still has. That takes `cargo test
--all` and `cargo clippy --all-targets` down with it, because the
workspace glob picks the crate up. Reported in #121.

Normalizing at each call site would have left the two halves free to
disagree about what the file says, so it happens once, at the top of the
function both of them go through. The reference the test compares
against is read the same way: on a CRLF checkout those two files differ
by their line endings alone, which is not a divergence worth failing on.

The .gitattributes is the other half. The Rust side can normalize what it
reads, but `compare_output.sh` diffs a generated `.d.ts` against a
checked-in one, and the bless script walks the README with awk; none of
that has a place to normalize. Pinning these files to LF in the working
tree is what makes those agree too.

## How this was checked

The extractor was pulled out of the crate and run against the real README,
once as it sits and once with every newline doubled to CRLF. Before:

    LF   rust block  -> Ok(474)
    CRLF rust block  -> panic: the README no longer has a line "## Example"
    CRLF ts   block  -> panic: the README no longer has a line "## Example"

After:

    LF   rust block  -> Ok(474)
    CRLF rust block  -> Ok(474)
    CRLF ts   block  -> Ok(181)

There is a test for it now, which asserts the two checkouts of the same text
extract the same block rather than asserting one particular string.

`cargo test -p test_readme_quickstart1` passes all six, `cargo clippy
--all-targets` is clean, `cargo fmt --all -- --check` is clean, and
`./test.sh` finishes with every reference identical.

`git ls-files --eol` reports every tracked `.md`, `.rs`, `.ts`, `.sh` and
`.toml` as LF in the working tree already, so the .gitattributes changes
nothing on a checkout that was fine and fixes the ones that were not.

Thanks for the report, and for chasing it past the first symptom — the note
that patching only the anchor moves the failure to the comparison is what
made it clear this belonged in one place rather than two.

Closes #121
