### PR TITLE
Record what type_params writes today, wrong output included

### DIFF
--- a/tests-e2e/reference_output/test_type_params1/test_type_params1.d.ts
+++ b/tests-e2e/reference_output/test_type_params1/test_type_params1.d.ts
@@ -1,0 +1,31 @@
+/* tslint:disable */
+/* eslint-disable */
+declare namespace CompoundDefault {
+    export type V<T = Record<string, number>> = { V: T };
+}
+
+export type CompoundDefault<T> = CompoundDefault.V<T = Record<string, number>>;
+
+declare namespace NoDefault {
+    export type V<T> = { V: T };
+}
+
+export type NoDefault<T> = NoDefault.V<T>;
+
+declare namespace SimpleDefault {
+    export type V<T = string> = { V: T };
+}
+
+export type SimpleDefault<T> = SimpleDefault.V<T = string>;
+
+export interface CompoundDefaultStruct<T = Record<string, number>> {
+    data: T;
+}
+
+export interface MatchingParam<T> {
+    data: T;
+}
+
+export interface RenamedParam<U> {
+    data: T;
+}

--- a/tests-e2e/test_type_params1/Cargo.toml
+++ b/tests-e2e/test_type_params1/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test_type_params1"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"

--- a/tests-e2e/test_type_params1/entry_point.rs
+++ b/tests-e2e/test_type_params1/entry_point.rs
@@ -35,8 +35,7 @@ pub struct MatchingParam<T> {
 // #112 — the union a namespaced enum writes puts the whole parameter spec in a
 // type-argument position, where a default is not allowed (TS1005). Measured:
 // this happens whenever the spec carries an `=`, with or without a comma, so
-// the two below fail the same way and the one after them does not. #112 says a
-// single parameter with no comma works; that is not what the reference shows.
+// the two below fail the same way and the one after them does not.
 #[derive(Tsify, Serialize, Deserialize)]
 #[tsify(namespace, type_params = "T = Record<string, number>")]
 pub enum CompoundDefault<T> {

--- a/tests-e2e/test_type_params1/entry_point.rs
+++ b/tests-e2e/test_type_params1/entry_point.rs
@@ -1,0 +1,70 @@
+#![allow(dead_code)]
+
+// What `#[tsify(type_params = "...")]` writes today, including the two ways it
+// is wrong. The reference records the current output rather than the intended
+// one, the way `test_generic_args1` records #76: the lines below marked as
+// broken should change when #112 and #113 are fixed, and the controls beside
+// them should not.
+//
+// The emitted `.d.ts` does not type-check. That is the bug, not a defect in
+// this crate, which is why there is no `tsc` step here yet. Measured against
+// TypeScript 5.9.3: TS1005 and TS1109 on the two unions carrying a default, and
+// TS2304 on `RenamedParam` when it is checked on its own — the parse errors
+// suppress the semantic pass when everything is in one file.
+
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+
+// #113 — the attribute renames the declared parameter list wholesale, and the
+// field keeps rendering the Rust parameter. `U` is declared and never used;
+// `T` is used and never declared (TS2304).
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(type_params = "U")]
+pub struct RenamedParam<T> {
+    pub data: T,
+}
+
+// The control for #113: names that happen to match the Rust parameters are the
+// case that works, which is what makes the bug easy to miss.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(type_params = "T")]
+pub struct MatchingParam<T> {
+    pub data: T,
+}
+
+// #112 — the union a namespaced enum writes puts the whole parameter spec in a
+// type-argument position, where a default is not allowed (TS1005). Measured:
+// this happens whenever the spec carries an `=`, with or without a comma, so
+// the two below fail the same way and the one after them does not. #112 says a
+// single parameter with no comma works; that is not what the reference shows.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(namespace, type_params = "T = Record<string, number>")]
+pub enum CompoundDefault<T> {
+    V(T),
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(namespace, type_params = "T = string")]
+pub enum SimpleDefault<T> {
+    V(T),
+}
+
+// The same argument from outside a namespace. There is no union here, so the
+// default lands in a declaration where it is legal, and this one type-checks.
+// The comma split #112 describes happens inside the parser either way; nothing
+// in this reference distinguishes a split spec from a rejoined one, so what a
+// fix changes here is not yet visible.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(type_params = "T = Record<string, number>")]
+pub struct CompoundDefaultStruct<T> {
+    pub data: T,
+}
+
+// The control for the two above: a namespaced enum whose `type_params` carries
+// no `=`. Its union is `NoDefault.V<T>`, which is valid, and it should stay
+// that way.
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(namespace, type_params = "T")]
+pub enum NoDefault<T> {
+    V(T),
+}


### PR DESCRIPTION
#112 and #113 are both about `#[tsify(type_params = "...")]` and neither has
anything in the tree that would notice if the output changed. This adds an
e2e crate whose reference records the current output rather than the intended
one, the way test_generic_args1 records #76: the broken lines are checked in,
and a fix shows up as a diff on them.

Writing it turned up a correction to #112, which has since been applied there.
The issue said the failure came from splitting the argument on every comma, and
that a single parameter with no comma — `type_params = "T = string"` — worked.
It does not. The union a
namespaced enum writes puts the whole parameter spec into a type-argument
position, where a default is not allowed, so both of these fail the same way:

    type_params = "T = Record<string, number>"   TS1005, TS1109
    type_params = "T = string"                   TS1005, TS1109
    type_params = "T"                            fine

The comma has nothing to do with it; the `=` does. The comma split is real —
the parser does it — but nothing in this output distinguishes a split spec
from a rejoined one, so what a fix changes there is still not visible. The
crate carries the `"T"` case as the control that has to keep working.

#113 reproduces as reported: `RenamedParam<U>` declares `U` and its field
renders `T`. It shows as TS2304 only when checked on its own, because the
parse errors above suppress the semantic pass when the file is checked whole.

Measured against TypeScript 5.9.3. There is no `tsc` step in the crate yet:
the output is invalid on purpose until these are fixed.

## What the reference records

```ts
export type CompoundDefault<T> = CompoundDefault.V<T = Record<string, number>>;
export type SimpleDefault<T>   = SimpleDefault.V<T = string>;
export type NoDefault<T>       = NoDefault.V<T>;

export interface CompoundDefaultStruct<T = Record<string, number>> { data: T; }
export interface MatchingParam<T> { data: T; }
export interface RenamedParam<U> { data: T; }
```

The first two lines and the last one are what should change. The third, fourth
and fifth are controls and should not.

`./test.sh`, `cargo clippy --all-targets` and `cargo fmt --all -- --check` are
all clean; the reference matches what the build emits, which is the point.

ref #112
ref #113

