### PR TITLE
Record what name collisions and #[declare] on an alias write today

### DIFF
--- a/tests-e2e/reference_output/test_declare_alias1/test_declare_alias1.d.ts
+++ b/tests-e2e/reference_output/test_declare_alias1/test_declare_alias1.d.ts
@@ -1,0 +1,13 @@
+/* tslint:disable */
+/* eslint-disable */
+export interface RenamedStruct {
+    a: number;
+}
+
+export type A = number[];
+
+export type B = number[];
+
+export type C = number[];
+
+export type RenamedEnum = { V: number };

--- a/tests-e2e/reference_output/test_name_collision1/test_name_collision1.d.ts
+++ b/tests-e2e/reference_output/test_name_collision1/test_name_collision1.d.ts
@@ -1,0 +1,42 @@
+/* tslint:disable */
+/* eslint-disable */
+export interface Duration {
+    secs: number;
+}
+
+export interface HoldsDuration {
+    d: { secs: number; nanos: number };
+}
+
+export interface HoldsGuarded {
+    range: { start: string; end: string };
+    result: { Ok: number } | { Err: string };
+    option: Option<number, string>;
+}
+
+export interface HoldsInterval {
+    i: Interval;
+}
+
+export interface HoldsStdTypes {
+    std_duration: { secs: number; nanos: number };
+    std_range: { start: number; end: number };
+}
+
+export interface Interval {
+    secs: number;
+}
+
+export interface Option<T, U> {
+    a: T;
+    b: U;
+}
+
+export interface Range<T> {
+    label: T;
+}
+
+export interface Result<T, E> {
+    good: T;
+    bad: E;
+}

--- a/tests-e2e/reference_output/test_name_collision1/test_name_collision1.d.ts
+++ b/tests-e2e/reference_output/test_name_collision1/test_name_collision1.d.ts
@@ -4,6 +4,10 @@ export interface Duration {
     secs: number;
 }
 
+export interface Fn {
+    called: boolean;
+}
+
 export interface HoldsDuration {
     d: { secs: number; nanos: number };
 }
@@ -12,6 +16,7 @@ export interface HoldsGuarded {
     range: { start: string; end: string };
     result: { Ok: number } | { Err: string };
     option: Option<number, string>;
+    func: () => void;
 }
 
 export interface HoldsInterval {

--- a/tests-e2e/test_declare_alias1/Cargo.toml
+++ b/tests-e2e/test_declare_alias1/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test_declare_alias1"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"

--- a/tests-e2e/test_declare_alias1/entry_point.rs
+++ b/tests-e2e/test_declare_alias1/entry_point.rs
@@ -1,0 +1,37 @@
+#![allow(dead_code)]
+
+// #116 — `#[declare]` takes arguments and forwards them for a struct or an
+// enum. On a type alias it accepts them and drops them: no error, no warning,
+// no note that the attribute went nowhere.
+//
+// The reference records the current output rather than the intended one, the
+// way `test_generic_args1` records #76. The alias rows should change when this
+// is fixed; the struct and enum rows beside them should not.
+
+use serde::{Deserialize, Serialize};
+use tsify::declare;
+
+// Forwarded, as they should be.
+#[declare(rename = "RenamedStruct")]
+#[derive(Serialize, Deserialize)]
+pub struct S {
+    pub a: u32,
+}
+
+#[declare(rename = "RenamedEnum")]
+#[derive(Serialize, Deserialize)]
+pub enum E {
+    V(u32),
+}
+
+// Broken: the alias keeps its Rust name.
+#[declare(rename = "RenamedAlias")]
+pub type A = Vec<u32>;
+
+// Broken the same way for the other container attributes an alias might want.
+#[declare(type_prefix = "Pre")]
+pub type B = Vec<u32>;
+
+// The control: an alias with no arguments, which is all the path supports today.
+#[declare]
+pub type C = Vec<u32>;

--- a/tests-e2e/test_name_collision1/Cargo.toml
+++ b/tests-e2e/test_name_collision1/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "test_name_collision1"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasm-bindgen = "0.2"
+tsify = { path = "../..", version = "*" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+[build-dependencies]
+wasm-bindgen-cli = "0.2"

--- a/tests-e2e/test_name_collision1/entry_point.rs
+++ b/tests-e2e/test_name_collision1/entry_point.rs
@@ -1,0 +1,88 @@
+#![allow(dead_code)]
+
+// #115 — a type of your own whose name matches one tsify special-cases is
+// rendered as the built-in wherever it is referenced. The declaration is
+// right; the reference is a different type, and it type-checks, so nothing
+// reports it.
+//
+// The reference records the current output rather than the intended one, the
+// way `test_generic_args1` records #76.
+//
+// Measured while writing this: whether a name collides depends on the arm.
+// `Duration`, `SystemTime`, `Path`, `PathBuf`, `ByteBuf` and `String` match on
+// the identifier alone, so any type of yours by that name is replaced. The
+// rest — `Option`, `Result`, `Vec`, `HashMap`, `Range` and so on — are guarded
+// by the number of type arguments, so they collide only when yours takes the
+// same number. #115 lists them together; the reference below separates them.
+
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+
+// ── Collides on the name alone ───────────────────────────────────────────────
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Duration {
+    pub secs: u64,
+}
+
+// Broken: renders `std::time::Duration`'s shape, not the interface above.
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct HoldsDuration {
+    pub d: crate::Duration,
+}
+
+// The types the shadowed names would otherwise be. Kept so that a fix which
+// stops special-casing altogether shows up here rather than only above.
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct HoldsStdTypes {
+    pub std_duration: std::time::Duration,
+    pub std_range: std::ops::Range<u32>,
+}
+
+// ── Guarded by the number of type arguments ──────────────────────────────────
+
+// Shadowing names the prelude uses would reach the code the derive generates,
+// so these live in a module of their own. The arm matches the terminal
+// identifier, so the path makes no difference.
+pub mod shadowed {
+    use super::*;
+
+    // One argument, and the arm wants one: broken, renders as a std range.
+    #[derive(Tsify, Serialize, Deserialize)]
+    pub struct Range<T> {
+        pub label: T,
+    }
+
+    // Two arguments, and the arm wants two: broken, renders as a union.
+    #[derive(Tsify, Serialize, Deserialize)]
+    pub struct Result<T, E> {
+        pub good: T,
+        pub bad: E,
+    }
+
+    // Same name, wrong arity for the arm: this one survives.
+    #[derive(Tsify, Serialize, Deserialize)]
+    pub struct Option<T, U> {
+        pub a: T,
+        pub b: U,
+    }
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct HoldsGuarded {
+    pub range: shadowed::Range<String>,
+    pub result: shadowed::Result<u32, String>,
+    pub option: shadowed::Option<u32, String>,
+}
+
+// ── Control ──────────────────────────────────────────────────────────────────
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Interval {
+    pub secs: u64,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct HoldsInterval {
+    pub i: crate::Interval,
+}

--- a/tests-e2e/test_name_collision1/entry_point.rs
+++ b/tests-e2e/test_name_collision1/entry_point.rs
@@ -9,11 +9,12 @@
 // way `test_generic_args1` records #76.
 //
 // Measured while writing this: whether a name collides depends on the arm.
-// `Duration`, `SystemTime`, `Path`, `PathBuf`, `ByteBuf` and `String` match on
-// the identifier alone, so any type of yours by that name is replaced. The
-// rest — `Option`, `Result`, `Vec`, `HashMap`, `Range` and so on — are guarded
-// by the number of type arguments, so they collide only when yours takes the
-// same number. #115 lists them together; the reference below separates them.
+// `String`, `str`, `char`, `Path`, `PathBuf`, `bool`, `ByteBuf`, `Duration`,
+// `SystemTime` and the `Fn` family match on the identifier alone, so a type of
+// yours by one of those names is replaced whatever shape it has. The rest —
+// `Option`, `Result`, `Vec`, `HashMap`, `Range` and so on — are guarded by the
+// number of type arguments, so they collide only when yours takes the same
+// number. #115 lists them together; the reference below separates them.
 
 use serde::{Deserialize, Serialize};
 use tsify::Tsify;
@@ -39,11 +40,12 @@ pub struct HoldsStdTypes {
     pub std_range: std::ops::Range<u32>,
 }
 
-// ── Guarded by the number of type arguments ──────────────────────────────────
+// ── Names the prelude also uses ──────────────────────────────────────────────
 
-// Shadowing names the prelude uses would reach the code the derive generates,
-// so these live in a module of their own. The arm matches the terminal
-// identifier, so the path makes no difference.
+// Shadowing these at the crate root would reach the code the derive generates,
+// so they live in a module of their own. The arm matches the terminal
+// identifier, so the path makes no difference. The first three are guarded by
+// argument count; `Fn` is not.
 pub mod shadowed {
     use super::*;
 
@@ -66,6 +68,13 @@ pub mod shadowed {
         pub a: T,
         pub b: U,
     }
+
+    // `Fn` is not a Rust keyword, and its arm carries no arity guard, so a
+    // type of yours by that name is replaced however many arguments it has.
+    #[derive(Tsify, Serialize, Deserialize)]
+    pub struct Fn {
+        pub called: bool,
+    }
 }
 
 #[derive(Tsify, Serialize, Deserialize)]
@@ -73,6 +82,7 @@ pub struct HoldsGuarded {
     pub range: shadowed::Range<String>,
     pub result: shadowed::Result<u32, String>,
     pub option: shadowed::Option<u32, String>,
+    pub func: shadowed::Fn,
 }
 
 // ── Control ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
#115 and #116 have nothing in the tree that would notice if their output
changed. These two crates record the current output rather than the intended
one, the way test_generic_args1 records #76.

Writing the first one sharpened #115. That issue lists the special-cased
identifiers together — `Result`, `Option`, `Path`, `PathBuf`, `Range`,
`Duration`, `SystemTime`, `ByteBuf` — as if a type of your own by any of those
names is replaced. Only some are. The arms split in two:

    matched on the name alone      String, str, char, Path, PathBuf, bool,
                                   ByteBuf, Duration, SystemTime, Fn family
    guarded by argument count      Box/Cow/Rc/Arc/Cell/RefCell (1), Vec family
                                   (1), HashMap/BTreeMap (2), HashSet family
                                   (1), Option (1), Result (2), Range family (1)

So a `Duration` of yours is always replaced, a `Range<T>` is replaced because
the arm wants one argument and yours has one, and an `Option<T, U>` survives
because the arm wants one and yours has two. The crate carries all three, and
the surviving case is what tells a fix from a regression.

#116 reproduces as reported, and the same silence covers the other container
attributes: `#[declare(rename = "...")]` and `#[declare(type_prefix = "...")]`
both leave the alias named after its Rust item. `#[declare]` with no arguments
is the control.

`./test.sh`, `cargo clippy --all-targets` and `cargo fmt --all -- --check` are
clean.

## What the references record

```ts
// test_name_collision1 — the three rows that should change
export interface HoldsDuration { d: { secs: number; nanos: number }; }
export interface HoldsGuarded {
    range: { start: string; end: string };
    result: { Ok: number } | { Err: string };
    option: Option<number, string>;      // survives; this one should not change
}
export interface HoldsInterval { i: Interval; }   // control

// test_declare_alias1 — the two aliases that should change
export type A = number[];      // asked for RenamedAlias
export type B = number[];      // asked for PreB
export type C = number[];      // control, no arguments
export interface RenamedStruct { a: number; }     // forwarded, as it should be
export type RenamedEnum = { V: number };          // forwarded
```

`Duration`, `Range` and `Result` are each declared in the same file and never
referenced, which is the shape #115 describes: the declaration is right and
every reference to it is a different type.

ref #115
ref #116
