### PR TITLE
Compare compile-fail diagnostics against one path spelling

### DIFF
--- a/tests/compile_fail.rs
+++ b/tests/compile_fail.rs
@@ -53,7 +53,10 @@ fn assert_diagnostic(stderr: &str, case: &CompileFailCase) {
             .map_or(diagnostic.len(), |index| index + 1);
         let diagnostic = &diagnostic[..diagnostic_end];
 
-        if diagnostic.contains(&location) {
+        // rustc spells the path with the platform's separator, so the same
+        // diagnostic points at `src/module.rs` on Unix and `src\module.rs` on
+        // Windows. Compare one spelling.
+        if diagnostic.replace('\\', "/").contains(&location) {
             return;
         }
         search_start = error_start + error.len();


### PR DESCRIPTION
`tests/compile_fail.rs` builds the expected location as `--> src/{module}.rs:{line}:`, but rustc spells the path with the platform's separator. On Windows every diagnostic reads `src\module.rs`, so no case has ever matched and the test fails there whatever the macro does:

```
missing diagnostic for duplicate_same_attribute at line 4: duplicate attribute
error: duplicate attribute
 --> src\duplicate_same_attribute.rs:4:27
```

CI runs on Linux, so it has always been green there and always red locally on Windows. Normalizing the separator before the comparison is enough; the rest of the matching is unchanged.

Split out of #109, where I had originally bundled it.
