### PR TITLE
Name types for the descriptor, without changing what it says yet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,13 @@ mod ts;
 pub use ts::Ts;
 mod error;
 pub use error::Error;
+/// Not a public API. Generated code needs a path it can name across the
+/// proc-macro boundary; nothing here is meant to be referred to by hand, and
+/// its shape is free to change.
+#[cfg(feature = "wasm-bindgen")]
+#[doc(hidden)]
+#[path = "macro_support.rs"]
+pub mod __macro_support;
 
 #[cfg(all(feature = "json", not(feature = "js")))]
 pub use gloo_utils::format::JsValueSerdeExt;

--- a/src/macro_support.rs
+++ b/src/macro_support.rs
@@ -1,0 +1,702 @@
+//! The name a type goes by inside a `#[wasm_bindgen]` signature.
+//!
+//! Not a public API. Everything here exists so that generated code can name a
+//! type across the proc-macro boundary; the shape of it is free to change.
+//!
+//! wasm-bindgen does not read the `typescript_custom_section` when it writes a
+//! signature. It reads a *descriptor* the module informs at build time, which
+//! for a named type is `NAMED_EXTERNREF`, a character count, then one `u32` per
+//! character. A `#[wasm_bindgen] extern` type carries one fixed name for all of
+//! its uses, so on its own it can only ever describe `Response`, never
+//! `Response<UserInfo>`.
+//!
+//! [`TsName`] rebuilds the name once per monomorphization instead: the derive
+//! unrolls the characters of the type's own declared name and defers to each
+//! type argument's own impl.
+//!
+//! # Two rules everything here obeys
+//!
+//! **Every character reaches the descriptor as a compile-time constant.**
+//! wasm-bindgen interprets descriptors with an interpreter that mirrors the
+//! size of linear memory but leaves it zero-filled, so a character read from
+//! memory arrives as `\0`. That rules out walking a `&str`, and it rules out
+//! `for c in ['a', 'b']`, which reads a materialized array: the loop runs zero
+//! times and the descriptor is silently short.
+//!
+//! **No loops.** The interpreter only learned `loop`, `if`/`else` and branches
+//! in wasm-bindgen 0.2.126, and this crate supports 0.2.104. A `while` in a
+//! descriptor fails there with `unknown instruction Loop`, in dev builds; a
+//! release build hides it, because rustc folds the loop away before the
+//! interpreter sees it. Conditions on a `const` parameter are fine — those fold
+//! at every profile — so [`ArrayName`] is unrolled behind them rather than
+//! counted.
+//!
+//! A length that disagrees with the characters is the failure worth guarding
+//! against: the count is what the decoder trusts, so a wrong one does not
+//! truncate a name, it desynchronizes everything after it in the descriptor.
+
+use std::borrow::Cow;
+use std::cell::{Cell, RefCell};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
+use std::ops::{Range, RangeInclusive};
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use wasm_bindgen::describe::{inform, NAMED_EXTERNREF, VECTOR};
+
+/// `#[tsify(missing_as_null)]`.
+pub const MISSING_AS_NULL: u8 = 1 << 0;
+/// `#[tsify(hashmap_as_object)]`.
+pub const HASHMAP_AS_OBJECT: u8 = 1 << 1;
+/// `#[tsify(large_number_types_as_bigints)]`.
+pub const LARGE_NUMBER_TYPES_AS_BIGINTS: u8 = 1 << 2;
+
+/// The bits above are the whole protocol between the derive and this module.
+/// Every other bit is reserved and ignored, so generated code from a newer
+/// macro crate names types the same way an older one does rather than failing
+/// to compile.
+pub const KNOWN_CONFIG_BITS: u8 =
+    MISSING_AS_NULL | HASHMAP_AS_OBJECT | LARGE_NUMBER_TYPES_AS_BIGINTS;
+
+/// Whether a missing value is written as `undefined` rather than `null`.
+const fn nullish_is_undefined(config: u8) -> bool {
+    cfg!(feature = "js") && config & MISSING_AS_NULL == 0
+}
+
+/// Whether a map is written as a `Map` rather than a plain object.
+const fn map_is_map(config: u8) -> bool {
+    cfg!(feature = "js") && config & HASHMAP_AS_OBJECT == 0
+}
+
+/// Whether the 64-bit integers are written as `bigint`.
+const fn wide_int_is_bigint(config: u8) -> bool {
+    cfg!(feature = "js") && config & LARGE_NUMBER_TYPES_AS_BIGINTS != 0
+}
+
+/// The TypeScript name a type goes by, under the serialization config of the
+/// value being written.
+///
+/// `CONFIG` is the config of the type the value is serialized *through*, not of
+/// the type being named. One `serde_wasm_bindgen::Serializer` is built from the
+/// root type's attributes and writes the whole value, nested types included, so
+/// a name that followed the nested type's own attributes would describe a shape
+/// that is never produced (see
+/// <https://github.com/madonoharu/tsify/issues/125>). Every impl here threads
+/// `CONFIG` down unchanged; only the root seeds it.
+pub trait TsName<const CONFIG: u8 = 0> {
+    /// The number of `char`s [`describe_name`](TsName::describe_name) informs.
+    const NAME_LEN: u32;
+
+    /// Informs the name one `char` at a time, in order.
+    fn describe_name();
+
+    /// Informs the whole `NAMED_EXTERNREF` descriptor for this name.
+    #[inline]
+    fn describe_named_externref() {
+        inform(NAMED_EXTERNREF);
+        inform(Self::NAME_LEN);
+        Self::describe_name();
+    }
+
+    /// Informs the descriptor for a vector of this name.
+    #[inline]
+    fn describe_named_externref_vector() {
+        inform(VECTOR);
+        Self::describe_named_externref();
+    }
+}
+
+/// Informs one `char` of a name.
+///
+/// Only ever pass a literal, or defer to another impl: a character that comes
+/// from memory reaches wasm-bindgen as `\0`.
+#[inline]
+pub fn inform_char(c: char) {
+    inform(c as u32);
+}
+
+/// Implements [`TsName`] for types whose name is fixed, spelled one `char` at a
+/// time so that each one is an immediate.
+macro_rules! ts_name {
+    ($($ty:ty),+ $(,)? => $($ch:literal),+ $(,)?) => {
+        ts_name!(@each [$($ch),+] $($ty),+);
+    };
+
+    (@each $name:tt $($ty:ty),+) => {
+        $(ts_name!(@one $ty, $name);)+
+    };
+
+    (@one $ty:ty, [$($ch:literal),+]) => {
+        impl<const C: u8> TsName<C> for $ty {
+            const NAME_LEN: u32 = [$($ch),+].len() as u32;
+
+            #[inline]
+            fn describe_name() {
+                $(inform_char($ch);)+
+            }
+        }
+    };
+}
+
+/// The same, for a name the config chooses between.
+macro_rules! ts_name_by_config {
+    ($($ty:ty),+ $(,)? => if $cond:ident { $($yes:literal),+ } else { $($no:literal),+ }) => {
+        ts_name_by_config!(@each $cond [$($yes),+] [$($no),+] $($ty),+);
+    };
+
+    (@each $cond:ident $yes:tt $no:tt $($ty:ty),+) => {
+        $(ts_name_by_config!(@one $cond, $ty, $yes, $no);)+
+    };
+
+    (@one $cond:ident, $ty:ty, [$($yes:literal),+], [$($no:literal),+]) => {
+        impl<const C: u8> TsName<C> for $ty {
+            const NAME_LEN: u32 = if $cond(C) {
+                [$($yes),+].len() as u32
+            } else {
+                [$($no),+].len() as u32
+            };
+
+            #[inline]
+            fn describe_name() {
+                if $cond(C) {
+                    $(inform_char($yes);)+
+                } else {
+                    $(inform_char($no);)+
+                }
+            }
+        }
+    };
+}
+
+ts_name!(u8, u16, u32, i8, i16, i32, f32, f64 => 'n', 'u', 'm', 'b', 'e', 'r');
+ts_name!(bool => 'b', 'o', 'o', 'l', 'e', 'a', 'n');
+ts_name!(String, str, char, Path, PathBuf => 's', 't', 'r', 'i', 'n', 'g');
+
+// `#[tsify(large_number_types_as_bigints)]` is the only reason these are not
+// plain numbers, and it is read from the root of the value being written.
+ts_name_by_config!(
+    u64, i64, usize, isize
+    => if wide_int_is_bigint { 'b', 'i', 'g', 'i', 'n', 't' } else { 'n', 'u', 'm', 'b', 'e', 'r' }
+);
+
+// 128-bit integers never fit a JS number; through JSON serde has already
+// narrowed them, which is a feature question rather than a config one.
+#[cfg(feature = "js")]
+ts_name!(u128, i128 => 'b', 'i', 'g', 'i', 'n', 't');
+#[cfg(not(feature = "js"))]
+ts_name!(u128, i128 => 'n', 'u', 'm', 'b', 'e', 'r');
+
+/// Wrappers serde sees through, so TypeScript does too.
+macro_rules! ts_name_transparent {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<const C: u8, T: TsName<C> + ?Sized> TsName<C> for $ty {
+                const NAME_LEN: u32 = <T as TsName<C>>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    <T as TsName<C>>::describe_name();
+                }
+            }
+        )+
+    };
+}
+
+ts_name_transparent!(&T, &mut T, Box<T>, Rc<T>, Arc<T>);
+
+macro_rules! ts_name_transparent_sized {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<const C: u8, T: TsName<C>> TsName<C> for $ty {
+                const NAME_LEN: u32 = <T as TsName<C>>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    <T as TsName<C>>::describe_name();
+                }
+            }
+        )+
+    };
+}
+
+ts_name_transparent_sized!(Cell<T>, RefCell<T>);
+
+impl<const C: u8, T: TsName<C> + ToOwned + ?Sized> TsName<C> for Cow<'_, T> {
+    const NAME_LEN: u32 = <T as TsName<C>>::NAME_LEN;
+
+    #[inline]
+    fn describe_name() {
+        <T as TsName<C>>::describe_name();
+    }
+}
+
+/// Sequences, as `T[]`.
+///
+/// The element is parenthesized where it has to be, which is why the union
+/// forms below carry their own parentheses.
+macro_rules! ts_name_array {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<const C: u8, T: TsName<C>> TsName<C> for $ty {
+                const NAME_LEN: u32 = <T as TsName<C>>::NAME_LEN + 2;
+
+                #[inline]
+                fn describe_name() {
+                    <T as TsName<C>>::describe_name();
+                    inform_char('[');
+                    inform_char(']');
+                }
+            }
+        )+
+    };
+}
+
+ts_name_array!(
+    Vec<T>,
+    VecDeque<T>,
+    LinkedList<T>,
+    HashSet<T>,
+    BTreeSet<T>,
+    [T]
+);
+
+/// Maps, as `Map<K, V>` or `Record<K, V>` depending on the config the value is
+/// written under.
+macro_rules! ts_name_map {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<const C: u8, K: TsName<C>, V: TsName<C>> TsName<C> for $ty {
+                // `Map<` or `Record<`, then K, `, `, V, `>`.
+                const NAME_LEN: u32 = (if map_is_map(C) { 3 } else { 6 })
+                    + 4
+                    + <K as TsName<C>>::NAME_LEN
+                    + <V as TsName<C>>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    if map_is_map(C) {
+                        inform_char('M');
+                        inform_char('a');
+                        inform_char('p');
+                    } else {
+                        inform_char('R');
+                        inform_char('e');
+                        inform_char('c');
+                        inform_char('o');
+                        inform_char('r');
+                        inform_char('d');
+                    }
+                    inform_char('<');
+                    <K as TsName<C>>::describe_name();
+                    inform_char(',');
+                    inform_char(' ');
+                    <V as TsName<C>>::describe_name();
+                    inform_char('>');
+                }
+            }
+        )+
+    };
+}
+
+ts_name_map!(HashMap<K, V>, BTreeMap<K, V>);
+
+/// Informs `undefined` or `null`, whichever the config writes.
+#[inline]
+fn describe_nullish(config: u8) {
+    if nullish_is_undefined(config) {
+        inform_char('u');
+        inform_char('n');
+        inform_char('d');
+        inform_char('e');
+        inform_char('f');
+        inform_char('i');
+        inform_char('n');
+        inform_char('e');
+        inform_char('d');
+    } else {
+        inform_char('n');
+        inform_char('u');
+        inform_char('l');
+        inform_char('l');
+    }
+}
+
+const fn nullish_len(config: u8) -> u32 {
+    if nullish_is_undefined(config) {
+        9
+    } else {
+        4
+    }
+}
+
+/// The unit type serializes to nothing, and is named for whatever that nothing
+/// is written as.
+impl<const C: u8> TsName<C> for () {
+    const NAME_LEN: u32 = nullish_len(C);
+
+    #[inline]
+    fn describe_name() {
+        describe_nullish(C);
+    }
+}
+
+/// `(T | undefined)`.
+///
+/// The parentheses are always written. A union is only legal unparenthesized in
+/// some of the positions a name can land in -- `Vec<Option<T>>` has to come out
+/// as `(T | undefined)[]` -- and a name has no context to decide from.
+impl<const C: u8, T: TsName<C>> TsName<C> for Option<T> {
+    // `(` + T + ` | ` + nullish + `)`
+    const NAME_LEN: u32 = <T as TsName<C>>::NAME_LEN + nullish_len(C) + 5;
+
+    #[inline]
+    fn describe_name() {
+        inform_char('(');
+        <T as TsName<C>>::describe_name();
+        inform_char(' ');
+        inform_char('|');
+        inform_char(' ');
+        describe_nullish(C);
+        inform_char(')');
+    }
+}
+
+/// `({ Ok: T } | { Err: E })`, which is what serde writes and what the
+/// declaration already renders.
+impl<const C: u8, T: TsName<C>, E: TsName<C>> TsName<C> for Result<T, E> {
+    // `({ Ok: ` T ` } | { Err: ` E ` })`
+    const NAME_LEN: u32 = 22 + <T as TsName<C>>::NAME_LEN + <E as TsName<C>>::NAME_LEN;
+
+    #[inline]
+    fn describe_name() {
+        inform_char('(');
+        inform_char('{');
+        inform_char(' ');
+        inform_char('O');
+        inform_char('k');
+        inform_char(':');
+        inform_char(' ');
+        <T as TsName<C>>::describe_name();
+        inform_char(' ');
+        inform_char('}');
+        inform_char(' ');
+        inform_char('|');
+        inform_char(' ');
+        inform_char('{');
+        inform_char(' ');
+        inform_char('E');
+        inform_char('r');
+        inform_char('r');
+        inform_char(':');
+        inform_char(' ');
+        <E as TsName<C>>::describe_name();
+        inform_char(' ');
+        inform_char('}');
+        inform_char(')');
+    }
+}
+
+/// Tuples, as `[A, B]`.
+macro_rules! ts_name_tuple {
+    ($(($($param:ident),+))+) => {
+        $(
+            impl<const C: u8, $($param: TsName<C>),+> TsName<C> for ($($param,)+) {
+                // `[` + each name + `, ` between each pair + `]`
+                const NAME_LEN: u32 = 2
+                    + tuple_separators(&[$(<$param as TsName<C>>::NAME_LEN),+])
+                    $(+ <$param as TsName<C>>::NAME_LEN)+;
+
+                #[inline]
+                fn describe_name() {
+                    inform_char('[');
+                    let mut first = true;
+                    $(
+                        if !first {
+                            inform_char(',');
+                            inform_char(' ');
+                        }
+                        first = false;
+                        <$param as TsName<C>>::describe_name();
+                    )+
+                    let _ = first;
+                    inform_char(']');
+                }
+            }
+        )+
+    };
+}
+
+/// `, ` between each pair of elements.
+const fn tuple_separators(names: &[u32]) -> u32 {
+    2 * (names.len() as u32 - 1)
+}
+
+ts_name_tuple! {
+    (A)
+    (A, B)
+    (A, B, C2)
+    (A, B, C2, D)
+    (A, B, C2, D, E)
+    (A, B, C2, D, E, F)
+    (A, B, C2, D, E, F, G)
+    (A, B, C2, D, E, F, G, H)
+    (A, B, C2, D, E, F, G, H, I)
+    (A, B, C2, D, E, F, G, H, I, J)
+    (A, B, C2, D, E, F, G, H, I, J, K)
+    (A, B, C2, D, E, F, G, H, I, J, K, L)
+    (A, B, C2, D, E, F, G, H, I, J, K, L, M)
+    (A, B, C2, D, E, F, G, H, I, J, K, L, M, N)
+    (A, B, C2, D, E, F, G, H, I, J, K, L, M, N, O)
+    (A, B, C2, D, E, F, G, H, I, J, K, L, M, N, O, P)
+}
+
+/// Fixed-size arrays, which the declaration path splits at sixteen: shorter
+/// ones are a tuple, longer ones a sequence.
+///
+/// Unrolled behind conditions on `N` rather than counted in a loop, because a
+/// loop in a descriptor is only interpretable from wasm-bindgen 0.2.126 and
+/// this crate supports 0.2.104. A condition on a `const` folds at every
+/// profile; a loop does not.
+impl<const C: u8, T: TsName<C>, const N: usize> TsName<C> for [T; N] {
+    const NAME_LEN: u32 = if N == 0 {
+        2
+    } else if N <= 16 {
+        2 + N as u32 * <T as TsName<C>>::NAME_LEN + 2 * (N as u32 - 1)
+    } else {
+        <T as TsName<C>>::NAME_LEN + 2
+    };
+
+    #[inline]
+    fn describe_name() {
+        if N > 16 {
+            <T as TsName<C>>::describe_name();
+            inform_char('[');
+            inform_char(']');
+        } else {
+            inform_char('[');
+            if N > 0 {
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 1 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 2 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 3 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 4 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 5 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 6 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 7 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 8 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 9 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 10 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 11 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 12 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 13 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 14 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            if N > 15 {
+                inform_char(',');
+                inform_char(' ');
+                <T as TsName<C>>::describe_name();
+            }
+            inform_char(']');
+        }
+    }
+}
+
+/// `{ secs: number; nanos: number }`, as the declaration renders it.
+impl<const C: u8> TsName<C> for Duration {
+    const NAME_LEN: u32 = 31;
+
+    #[inline]
+    fn describe_name() {
+        inform_char('{');
+        inform_char(' ');
+        inform_char('s');
+        inform_char('e');
+        inform_char('c');
+        inform_char('s');
+        inform_char(':');
+        inform_char(' ');
+        inform_char('n');
+        inform_char('u');
+        inform_char('m');
+        inform_char('b');
+        inform_char('e');
+        inform_char('r');
+        inform_char(';');
+        inform_char(' ');
+        inform_char('n');
+        inform_char('a');
+        inform_char('n');
+        inform_char('o');
+        inform_char('s');
+        inform_char(':');
+        inform_char(' ');
+        inform_char('n');
+        inform_char('u');
+        inform_char('m');
+        inform_char('b');
+        inform_char('e');
+        inform_char('r');
+        inform_char(' ');
+        inform_char('}');
+    }
+}
+
+/// `{ secs_since_epoch: number; nanos_since_epoch: number }`.
+impl<const C: u8> TsName<C> for SystemTime {
+    const NAME_LEN: u32 = 55;
+
+    #[inline]
+    fn describe_name() {
+        inform_char('{');
+        inform_char(' ');
+        inform_char('s');
+        inform_char('e');
+        inform_char('c');
+        inform_char('s');
+        inform_char('_');
+        inform_char('s');
+        inform_char('i');
+        inform_char('n');
+        inform_char('c');
+        inform_char('e');
+        inform_char('_');
+        inform_char('e');
+        inform_char('p');
+        inform_char('o');
+        inform_char('c');
+        inform_char('h');
+        inform_char(':');
+        inform_char(' ');
+        inform_char('n');
+        inform_char('u');
+        inform_char('m');
+        inform_char('b');
+        inform_char('e');
+        inform_char('r');
+        inform_char(';');
+        inform_char(' ');
+        inform_char('n');
+        inform_char('a');
+        inform_char('n');
+        inform_char('o');
+        inform_char('s');
+        inform_char('_');
+        inform_char('s');
+        inform_char('i');
+        inform_char('n');
+        inform_char('c');
+        inform_char('e');
+        inform_char('_');
+        inform_char('e');
+        inform_char('p');
+        inform_char('o');
+        inform_char('c');
+        inform_char('h');
+        inform_char(':');
+        inform_char(' ');
+        inform_char('n');
+        inform_char('u');
+        inform_char('m');
+        inform_char('b');
+        inform_char('e');
+        inform_char('r');
+        inform_char(' ');
+        inform_char('}');
+    }
+}
+
+/// `{ start: T; end: T }`, for both range forms.
+macro_rules! ts_name_range {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl<const C: u8, T: TsName<C>> TsName<C> for $ty {
+                // `{ start: ` T `; end: ` T ` }`
+                const NAME_LEN: u32 = 18 + 2 * <T as TsName<C>>::NAME_LEN;
+
+                #[inline]
+                fn describe_name() {
+                    inform_char('{');
+                    inform_char(' ');
+                    inform_char('s');
+                    inform_char('t');
+                    inform_char('a');
+                    inform_char('r');
+                    inform_char('t');
+                    inform_char(':');
+                    inform_char(' ');
+                    <T as TsName<C>>::describe_name();
+                    inform_char(';');
+                    inform_char(' ');
+                    inform_char('e');
+                    inform_char('n');
+                    inform_char('d');
+                    inform_char(':');
+                    inform_char(' ');
+                    <T as TsName<C>>::describe_name();
+                    inform_char(' ');
+                    inform_char('}');
+                }
+            }
+        )+
+    };
+}
+
+ts_name_range!(Range<T>, RangeInclusive<T>);

--- a/tests/expand/borrow.expanded.rs
+++ b/tests/expand/borrow.expanded.rs
@@ -231,6 +231,20 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<'a, const __TSIFY_CONFIG: u8> tsify::__macro_support::TsName<__TSIFY_CONFIG>
+    for Borrow<'a> {
+        const NAME_LEN: u32 = 6u32;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('B');
+            tsify::__macro_support::inform_char('o');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('o');
+            tsify::__macro_support::inform_char('w');
+        }
+    }
+    #[automatically_derived]
     impl<'a> WasmDescribe for Borrow<'a> {
         #[inline]
         fn describe() {

--- a/tests/expand/generic_constrained_struct.expanded.rs
+++ b/tests/expand/generic_constrained_struct.expanded.rs
@@ -237,6 +237,36 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<
+        T: Constraint,
+        const __TSIFY_CONFIG: u8,
+    > tsify::__macro_support::TsName<__TSIFY_CONFIG> for GenericStruct<T>
+    where
+        T: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+    {
+        const NAME_LEN: u32 = 15u32
+            + <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('S');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('u');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('<');
+            <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char('>');
+        }
+    }
+    #[automatically_derived]
     impl<T: Constraint> WasmDescribe for GenericStruct<T> {
         #[inline]
         fn describe() {
@@ -668,6 +698,37 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<
+        T: Constraint,
+        const __TSIFY_CONFIG: u8,
+    > tsify::__macro_support::TsName<__TSIFY_CONFIG> for GenericNewtype<T>
+    where
+        T: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+    {
+        const NAME_LEN: u32 = 16u32
+            + <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('N');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('w');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('y');
+            tsify::__macro_support::inform_char('p');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('<');
+            <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char('>');
+        }
+    }
+    #[automatically_derived]
     impl<T: Constraint> WasmDescribe for GenericNewtype<T> {
         #[inline]
         fn describe() {
@@ -1097,6 +1158,35 @@ const _: () = {
             hashmap_as_object: false,
             large_number_types_as_bigints: false,
         };
+    }
+    #[automatically_derived]
+    impl<
+        T: Iterator<Item = u32>,
+        const __TSIFY_CONFIG: u8,
+    > tsify::__macro_support::TsName<__TSIFY_CONFIG> for GenericAssoc<T>
+    where
+        T: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+    {
+        const NAME_LEN: u32 = 14u32
+            + <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('A');
+            tsify::__macro_support::inform_char('s');
+            tsify::__macro_support::inform_char('s');
+            tsify::__macro_support::inform_char('o');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('<');
+            <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char('>');
+        }
     }
     #[automatically_derived]
     impl<T: Iterator<Item = u32>> WasmDescribe for GenericAssoc<T> {
@@ -1534,6 +1624,32 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<
+        'a: 'b,
+        'b,
+        const __TSIFY_CONFIG: u8,
+    > tsify::__macro_support::TsName<__TSIFY_CONFIG> for GenericLifetime<'a, 'b> {
+        const NAME_LEN: u32 = 15u32;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('L');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('f');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('m');
+            tsify::__macro_support::inform_char('e');
+        }
+    }
+    #[automatically_derived]
     impl<'a: 'b, 'b> WasmDescribe for GenericLifetime<'a, 'b> {
         #[inline]
         fn describe() {
@@ -1963,6 +2079,28 @@ const _: () = {
             hashmap_as_object: false,
             large_number_types_as_bigints: false,
         };
+    }
+    #[automatically_derived]
+    impl<
+        const N: usize,
+        const __TSIFY_CONFIG: u8,
+    > tsify::__macro_support::TsName<__TSIFY_CONFIG> for GenericConst<N> {
+        const NAME_LEN: u32 = 12u32;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('C');
+            tsify::__macro_support::inform_char('o');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('s');
+            tsify::__macro_support::inform_char('t');
+        }
     }
     #[automatically_derived]
     impl<const N: usize> WasmDescribe for GenericConst<N> {

--- a/tests/expand/generic_enum.expanded.rs
+++ b/tests/expand/generic_enum.expanded.rs
@@ -237,6 +237,37 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<T, U, const __TSIFY_CONFIG: u8> tsify::__macro_support::TsName<__TSIFY_CONFIG>
+    for GenericEnum<T, U>
+    where
+        T: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+        U: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+    {
+        const NAME_LEN: u32 = 15u32
+            + <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN
+            + <U as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('E');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('u');
+            tsify::__macro_support::inform_char('m');
+            tsify::__macro_support::inform_char('<');
+            <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char(',');
+            tsify::__macro_support::inform_char(' ');
+            <U as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char('>');
+        }
+    }
+    #[automatically_derived]
     impl<T, U> WasmDescribe for GenericEnum<T, U> {
         #[inline]
         fn describe() {

--- a/tests/expand/generic_struct.expanded.rs
+++ b/tests/expand/generic_struct.expanded.rs
@@ -236,6 +236,34 @@ const _: () = {
         };
     }
     #[automatically_derived]
+    impl<T, const __TSIFY_CONFIG: u8> tsify::__macro_support::TsName<__TSIFY_CONFIG>
+    for GenericStruct<T>
+    where
+        T: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+    {
+        const NAME_LEN: u32 = 15u32
+            + <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('S');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('u');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('<');
+            <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char('>');
+        }
+    }
+    #[automatically_derived]
     impl<T> WasmDescribe for GenericStruct<T> {
         #[inline]
         fn describe() {
@@ -665,6 +693,35 @@ const _: () = {
             hashmap_as_object: false,
             large_number_types_as_bigints: false,
         };
+    }
+    #[automatically_derived]
+    impl<T, const __TSIFY_CONFIG: u8> tsify::__macro_support::TsName<__TSIFY_CONFIG>
+    for GenericNewtype<T>
+    where
+        T: tsify::__macro_support::TsName<__TSIFY_CONFIG>,
+    {
+        const NAME_LEN: u32 = 16u32
+            + <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('G');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('r');
+            tsify::__macro_support::inform_char('i');
+            tsify::__macro_support::inform_char('c');
+            tsify::__macro_support::inform_char('N');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('w');
+            tsify::__macro_support::inform_char('t');
+            tsify::__macro_support::inform_char('y');
+            tsify::__macro_support::inform_char('p');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('<');
+            <T as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            tsify::__macro_support::inform_char('>');
+        }
     }
     #[automatically_derived]
     impl<T> WasmDescribe for GenericNewtype<T> {

--- a/tests/expand/rename.expanded.rs
+++ b/tests/expand/rename.expanded.rs
@@ -236,4 +236,27 @@ const _: () = {
             large_number_types_as_bigints: false,
         };
     }
+    #[automatically_derived]
+    impl<const __TSIFY_CONFIG: u8> tsify::__macro_support::TsName<__TSIFY_CONFIG>
+    for RustType {
+        const NAME_LEN: u32 = 15u32;
+        #[inline]
+        fn describe_name() {
+            tsify::__macro_support::inform_char('R');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('n');
+            tsify::__macro_support::inform_char('a');
+            tsify::__macro_support::inform_char('m');
+            tsify::__macro_support::inform_char('e');
+            tsify::__macro_support::inform_char('d');
+            tsify::__macro_support::inform_char('W');
+            tsify::__macro_support::inform_char('a');
+            tsify::__macro_support::inform_char('s');
+            tsify::__macro_support::inform_char('m');
+            tsify::__macro_support::inform_char('T');
+            tsify::__macro_support::inform_char('y');
+            tsify::__macro_support::inform_char('p');
+            tsify::__macro_support::inform_char('e');
+        }
+    }
 };

--- a/tests/name.rs
+++ b/tests/name.rs
@@ -1,0 +1,188 @@
+//! The names types go by inside a `#[wasm_bindgen]` signature.
+//!
+//! Only the length is checked here: informing the characters needs
+//! wasm-bindgen's descriptor import, which exists only in a wasm build. A
+//! length that disagrees with the characters is the failure worth catching
+//! anyway — the count is what the decoder trusts, so a wrong one does not
+//! truncate a name, it desynchronizes everything after it in the descriptor.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use tsify::__macro_support::{
+    TsName, HASHMAP_AS_OBJECT, LARGE_NUMBER_TYPES_AS_BIGINTS, MISSING_AS_NULL,
+};
+use tsify::Tsify;
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct UserInfo {
+    id: u32,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Response<T> {
+    data: T,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Pair<A, B> {
+    left: A,
+    right: B,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(rename = "Renamed")]
+pub struct Named<T> {
+    data: T,
+}
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Tagged<T> {
+    #[serde(skip)]
+    tag: std::marker::PhantomData<T>,
+    id: u32,
+}
+
+#[derive(Tsify, Serialize)]
+pub struct Sliced<'a, const N: usize> {
+    data: &'a str,
+}
+
+#[track_caller]
+fn assert_name<const C: u8, T: TsName<C>>(expected: &str) {
+    assert_eq!(
+        <T as TsName<C>>::NAME_LEN,
+        expected.chars().count() as u32,
+        "name length for `{expected}`"
+    );
+}
+
+/// The default config: what a type reached from a root declaring no attributes
+/// is named under.
+const PLAIN: u8 = 0;
+
+#[test]
+fn test_derived_names() {
+    assert_name::<PLAIN, UserInfo>("UserInfo");
+    assert_name::<PLAIN, Response<UserInfo>>("Response<UserInfo>");
+    assert_name::<PLAIN, Response<Response<UserInfo>>>("Response<Response<UserInfo>>");
+    assert_name::<PLAIN, Pair<u32, String>>("Pair<number, string>");
+    assert_name::<PLAIN, Response<Pair<u32, String>>>("Response<Pair<number, string>>");
+
+    // `rename` names the declaration, so it names the type.
+    assert_name::<PLAIN, Named<UserInfo>>("Renamed<UserInfo>");
+
+    // A parameter no field mentions is declared nowhere, so applying it to the
+    // declared name would be a type error in the `.d.ts`. Lifetimes and const
+    // parameters never reach TypeScript at all.
+    assert_name::<PLAIN, Tagged<UserInfo>>("Tagged");
+    assert_name::<PLAIN, Sliced<'_, 3>>("Sliced");
+}
+
+#[test]
+fn test_scalar_names() {
+    assert_name::<PLAIN, u8>("number");
+    assert_name::<PLAIN, f64>("number");
+    assert_name::<PLAIN, bool>("boolean");
+    assert_name::<PLAIN, String>("string");
+    assert_name::<PLAIN, char>("string");
+    assert_name::<PLAIN, ()>(if cfg!(feature = "js") {
+        "undefined"
+    } else {
+        "null"
+    });
+}
+
+#[test]
+fn test_container_names() {
+    assert_name::<PLAIN, Vec<String>>("string[]");
+    assert_name::<PLAIN, Box<UserInfo>>("UserInfo");
+    assert_name::<PLAIN, &[u32]>("number[]");
+    assert_name::<PLAIN, Duration>("{ secs: number; nanos: number }");
+    assert_name::<PLAIN, SystemTime>("{ secs_since_epoch: number; nanos_since_epoch: number }");
+    assert_name::<PLAIN, std::ops::Range<u32>>("{ start: number; end: number }");
+    assert_name::<PLAIN, std::ops::RangeInclusive<u32>>("{ start: number; end: number }");
+}
+
+#[test]
+fn test_the_types_that_had_no_name() {
+    // Everything the declaration path already renders has to keep compiling as
+    // a type argument. These are the ones that did not, and that stopped
+    // `tests-e2e/test_generic_args1` from building.
+    assert_name::<PLAIN, Result<u32, String>>("({ Ok: number } | { Err: string })");
+    assert_name::<PLAIN, (u32, String)>("[number, string]");
+    assert_name::<PLAIN, (u32,)>("[number]");
+    assert_name::<PLAIN, (u32, u32, u32, u32)>("[number, number, number, number]");
+    assert_name::<PLAIN, Response<Result<u32, String>>>(
+        "Response<({ Ok: number } | { Err: string })>",
+    );
+    assert_name::<PLAIN, Response<(u32, String)>>("Response<[number, string]>");
+}
+
+#[test]
+fn test_fixed_size_arrays_split_where_the_declaration_splits() {
+    // The declaration path renders sixteen or fewer as a tuple, and anything
+    // longer as a sequence.
+    assert_name::<PLAIN, [u32; 0]>("[]");
+    assert_name::<PLAIN, [u32; 1]>("[number]");
+    assert_name::<PLAIN, [u32; 2]>("[number, number]");
+    assert_name::<PLAIN, [u32; 16]>(&format!("[{}]", ["number"; 16].join(", ")));
+    assert_name::<PLAIN, [u32; 17]>("number[]");
+    assert_name::<PLAIN, [u32; 20]>("number[]");
+}
+
+#[test]
+fn test_the_config_reaches_the_name() {
+    if cfg!(feature = "js") {
+        assert_name::<PLAIN, HashMap<String, u32>>("Map<string, number>");
+        assert_name::<HASHMAP_AS_OBJECT, HashMap<String, u32>>("Record<string, number>");
+
+        assert_name::<PLAIN, Option<u32>>("(number | undefined)");
+        assert_name::<MISSING_AS_NULL, Option<u32>>("(number | null)");
+
+        assert_name::<PLAIN, u64>("number");
+        assert_name::<LARGE_NUMBER_TYPES_AS_BIGINTS, u64>("bigint");
+    } else {
+        // Without `js` the value goes through JSON, which settles all three.
+        assert_name::<PLAIN, HashMap<String, u32>>("Record<string, number>");
+        assert_name::<HASHMAP_AS_OBJECT, HashMap<String, u32>>("Record<string, number>");
+
+        assert_name::<PLAIN, Option<u32>>("(number | null)");
+        assert_name::<MISSING_AS_NULL, Option<u32>>("(number | null)");
+
+        assert_name::<PLAIN, u64>("number");
+        assert_name::<LARGE_NUMBER_TYPES_AS_BIGINTS, u64>("number");
+    }
+}
+
+#[test]
+fn test_the_config_reaches_the_whole_way_down() {
+    // One serializer, built from the root type's attributes, writes the whole
+    // value — so a derived type passes the config it is asked for straight
+    // through, and a map two levels down still follows the root.
+    if cfg!(feature = "js") {
+        assert_name::<PLAIN, Response<Response<HashMap<String, u32>>>>(
+            "Response<Response<Map<string, number>>>",
+        );
+        assert_name::<HASHMAP_AS_OBJECT, Response<Response<HashMap<String, u32>>>>(
+            "Response<Response<Record<string, number>>>",
+        );
+    }
+}
+
+#[test]
+fn test_unknown_config_bits_are_ignored() {
+    // A newer macro crate may set a bit this one does not know. Naming the type
+    // anyway, rather than failing to compile, is what keeps the two versions
+    // usable together.
+    const UNKNOWN: u8 = 1 << 7;
+
+    assert_name::<UNKNOWN, HashMap<String, u32>>(if cfg!(feature = "js") {
+        "Map<string, number>"
+    } else {
+        "Record<string, number>"
+    });
+    assert_name::<{ HASHMAP_AS_OBJECT | (1 << 7) }, HashMap<String, u32>>("Record<string, number>");
+}

--- a/tsify-macros/src/decl.rs
+++ b/tsify-macros/src/decl.rs
@@ -312,6 +312,16 @@ impl Decl {
             Decl::TsEnum(decl) => &decl.id,
         }
     }
+
+    /// The parameters the declaration takes, which is not every parameter the
+    /// Rust type takes: one that no field mentions has nothing to declare.
+    pub fn type_params(&self) -> &[String] {
+        match self {
+            Decl::TsTypeAlias(decl) => &decl.type_params,
+            Decl::TsInterface(decl) => &decl.type_params,
+            Decl::TsEnum(decl) => &decl.type_params,
+        }
+    }
 }
 
 impl Display for Decl {

--- a/tsify-macros/src/wasm_bindgen.rs
+++ b/tsify-macros/src/wasm_bindgen.rs
@@ -25,6 +25,8 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
     let generics = cont.generics_without_defaults();
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let ts_name = expand_ts_name(cont, &decl);
+
     let typescript_custom_section = quote! {
         #[wasm_bindgen(typescript_custom_section)]
         const TS_APPEND_CONTENT: &'static str = #decl_str;
@@ -104,12 +106,113 @@ pub fn expand(cont: &Container, decl: Decl) -> TokenStream {
                 };
             }
 
+            #ts_name
             #typescript_custom_section
             #wasm_describe
             #into_wasm_abi
             #from_wasm_abi
             #maybe_deprecated
         };
+    }
+}
+
+/// The declaration's parameters, resolved back to the Rust type parameters they
+/// name.
+///
+/// `None` when one of them names no Rust parameter — `#[tsify(type_params)]`
+/// can say anything — which leaves nothing to compose that argument's name
+/// from, so the type keeps naming itself by its bare id.
+fn name_type_params(cont: &Container, decl: &Decl) -> Option<Vec<syn::Ident>> {
+    decl.type_params()
+        .iter()
+        .map(|declared| {
+            cont.generics()
+                .type_params()
+                .find(|param| param.ident == *declared)
+                .map(|param| param.ident.clone())
+        })
+        .collect()
+}
+
+/// Spells out the type's TypeScript name for `TsName`, one `char` at a time,
+/// deferring to each argument's own impl for the arguments.
+///
+/// Unrolled rather than read from `DECL` because wasm-bindgen interprets the
+/// descriptor without the module's data segments loaded, so a character that
+/// comes from memory reaches it as a NUL.
+///
+/// The impl is generic over the config it is asked for and passes it down
+/// unchanged. One serializer, built from the root type's attributes, writes the
+/// whole value; a name that switched to this type's own attributes partway down
+/// would describe a shape that is never produced (#125).
+fn expand_ts_name(cont: &Container, decl: &Decl) -> TokenStream {
+    let ident = cont.ident();
+    let name_params = name_type_params(cont, decl).unwrap_or_default();
+
+    let mut generics = cont.generics_without_defaults();
+    if !name_params.is_empty() {
+        let where_clause = generics.make_where_clause();
+        for param in &name_params {
+            where_clause
+                .predicates
+                .push(parse_quote!(#param: tsify::__macro_support::TsName<__TSIFY_CONFIG>));
+        }
+    }
+
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+    let impl_params = generics.params.iter();
+
+    let id_chars = decl.id().chars().collect::<Vec<_>>();
+    let id_len = id_chars.len() as u32;
+    let id = quote!(#(tsify::__macro_support::inform_char(#id_chars);)*);
+
+    let (name_len, describe_name) = if name_params.is_empty() {
+        (quote!(#id_len), id)
+    } else {
+        // The id, `<`, `>`, and `, ` between each pair of arguments.
+        let punctuation = id_len + 2 + 2 * (name_params.len() as u32 - 1);
+
+        let args = name_params.iter().enumerate().map(|(i, param)| {
+            let separator = (i > 0).then(|| {
+                quote! {
+                    tsify::__macro_support::inform_char(',');
+                    tsify::__macro_support::inform_char(' ');
+                }
+            });
+
+            quote! {
+                #separator
+                <#param as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::describe_name();
+            }
+        });
+
+        (
+            quote! {
+                #punctuation
+                #(+ <#name_params as tsify::__macro_support::TsName<__TSIFY_CONFIG>>::NAME_LEN)*
+            },
+            quote! {
+                #id
+                tsify::__macro_support::inform_char('<');
+                #(#args)*
+                tsify::__macro_support::inform_char('>');
+            },
+        )
+    };
+
+    quote! {
+        #[automatically_derived]
+        impl<#(#impl_params,)* const __TSIFY_CONFIG: u8>
+            tsify::__macro_support::TsName<__TSIFY_CONFIG> for #ident #ty_generics
+            #where_clause
+        {
+            const NAME_LEN: u32 = #name_len;
+
+            #[inline]
+            fn describe_name() {
+                #describe_name
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Half A of the split you suggested. Nothing here reaches a `.d.ts`: it is the carrier for #76 and a set of names for the types the declaration path already renders, so it can be read for whether the protocol is right rather than for output diffs. B is stacked on top at #109.

**The config is the root's, not the type's own.** Taking #125 as the contract: one serializer, built from the root type's attributes, writes the whole value, so every impl threads `CONFIG` down unchanged and a nested `HashMap` is named the way the root writes it. My earlier suggestion — switching to the lexical inner config — would have made that mismatch type-check, which is what you were guarding against.

Encoding it as a const-generic parameter is what keeps `NAME_LEN` a compile-time constant; reading it from an associated const in a bound needs `generic_const_exprs`. The bits are a protocol between the two crates, not an API: unknown ones are ignored, so a newer macro crate names a type the same way an older library does rather than failing to compile.

**Two rules the descriptor imposes, both measured at 0.2.104.** Every character must arrive as an immediate — and it is not only `&str`: `for c in ['a','b']` walks a materialized array, informs nothing, and fails as a truncated descriptor. And no loops, since the interpreter only learned `loop`/`if`/branches in 0.2.126. Conditions on a `const` fold at every profile, so `[T; N]` is unrolled behind them and makes the same split at sixteen the declaration makes. Verified at `=0.2.104` with the loop kept as a control, which reproduced your `unknown instruction Loop`; `[T; 0]`, `[T; 1]`, `[T; 2]`, `[T; 16]`, `[T; 17]` all come out right in dev and release. **No MSRV bump needed.**

`Result`, tuples, `Duration`, `SystemTime` and the ranges are here because a type argument that stops compiling would be worse than the bug. `tests/name.rs` pins every length against the name it spells — worth doing: it caught three wrong constants I had written by hand.

`#[diagnostic::on_unimplemented]` is dropped and both manifests are untouched, as you asked. Everything is behind `#[doc(hidden)] pub mod __macro_support`; no public trait, no `ts_name!`.

**Not covered:** `ByteBuf`, which cannot be named without an optional `serde_bytes` dependency. Tell me if you want that added.

All e2e references are byte-identical. Both feature sets, fmt and clippy clean.