### PR TITLE
Build one crate in dev at the wasm-bindgen we claim to support

### DIFF
--- a/tests-e2e/build_all.sh
+++ b/tests-e2e/build_all.sh
@@ -10,10 +10,11 @@ set -e
 # script, from wherever a person happens to be.
 ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
 
-# Find all Cargo.toml files in the root directory and its direct subdirectories
-FILES=$(find "$ROOT_DIR" -maxdepth 2 -name Cargo.toml)
-
-for FILE in $FILES; do
+# Find all Cargo.toml files in the root directory and its direct subdirectories.
+# Read as NUL-separated records rather than splitting one string on whitespace:
+# `ROOT_DIR` is absolute now, so a checkout under a path with a space in it
+# would otherwise arrive here as several fragments.
+while IFS= read -r -d '' FILE; do
     # Get the directory of the file
     DIR=$(dirname "$FILE")
     # Push the directory onto the stack and change to it
@@ -27,7 +28,7 @@ for FILE in $FILES; do
     wasm-pack build
     # Pop the directory from the stack and change back to the original directory
     popd > /dev/null || exit
-done
+done < <(find "$ROOT_DIR" -maxdepth 2 -name Cargo.toml -print0)
 
 # The reference-output crates above are release builds. Keep the one debug
 # descriptor check separate: running every crate again would double this suite,

--- a/tests-e2e/build_all.sh
+++ b/tests-e2e/build_all.sh
@@ -5,8 +5,10 @@
 # artifacts.
 set -e
 
-# Define the root directory for the search
-ROOT_DIR="tests-e2e"
+# Resolved from the script rather than the caller's directory: this is invoked
+# from `test.sh` at the repository root and, since it now calls a sibling
+# script, from wherever a person happens to be.
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 # Find all Cargo.toml files in the root directory and its direct subdirectories
 FILES=$(find "$ROOT_DIR" -maxdepth 2 -name Cargo.toml)
@@ -26,3 +28,9 @@ for FILE in $FILES; do
     # Pop the directory from the stack and change back to the original directory
     popd > /dev/null || exit
 done
+
+# The reference-output crates above are release builds. Keep the one debug
+# descriptor check separate: running every crate again would double this suite,
+# while a release build or a current wasm-bindgen interpreter would each hide
+# the compatibility failure it is meant to catch.
+"$ROOT_DIR/build_minimum_wasm_bindgen.sh"

--- a/tests-e2e/build_minimum_wasm_bindgen.sh
+++ b/tests-e2e/build_minimum_wasm_bindgen.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+manifest_template="$repo_root/tests-e2e/minimum_wasm_bindgen.Cargo.toml"
+source_file=${1:-"$repo_root/tests-e2e/minimum_wasm_bindgen.rs"}
+
+if [ "$#" -gt 1 ] || [ ! -f "$source_file" ]; then
+    echo "usage: $0 [entry-point.rs]" >&2
+    exit 2
+fi
+
+# wasm-bindgen executes descriptors with its own interpreter. The interpreter
+# in the declared minimum cannot execute control flow or unaligned byte access
+# left in a dev Wasm module; release optimization can fold both away, and newer
+# interpreters accept both. The compatibility gate is therefore this one small
+# crate built with --dev *and* with the dependency and matching CLI pinned to
+# the declared minimum. Neither half is a useful test on its own.
+#
+# Cargo reports a bare `0.2.104` requirement as `^0.2.104`. Accept exactly that
+# simple shape so Cargo.toml remains the only place that owns the version. If
+# the requirement becomes a range or moves, this extraction fails loudly
+# instead of silently testing a different floor.
+minimum_version=$(
+    cargo metadata \
+        --manifest-path "$repo_root/Cargo.toml" \
+        --no-deps \
+        --format-version 1 \
+        | /usr/bin/jq -er --arg manifest "$repo_root/Cargo.toml" '
+            [
+                .packages[]
+                | select(.manifest_path == $manifest)
+                | .dependencies[]
+                | select(.name == "wasm-bindgen" and .optional == true)
+                | .req
+                | capture("^\\^(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)$").version
+            ]
+            | if length == 1 then .[0]
+              else error("expected one simple wasm-bindgen minimum requirement")
+              end
+        '
+)
+
+# Keep Cargo.lock, target, and pkg outside tests-e2e. Besides leaving no stale
+# workspace member behind, this lets the normal release build keep its own pkg
+# output. wasm-pack selects the wasm-bindgen CLI matching the exact library
+# version in this generated manifest.
+probe_dir=$(mktemp -d "${TMPDIR:-/tmp}/tsify-wasm-bindgen-minimum.XXXXXX")
+trap 'rm -rf "$probe_dir"' EXIT
+
+# JSON strings are valid TOML basic strings for a filesystem path, and jq
+# handles any quote or backslash in the checkout path before it is inserted.
+tsify_path=$(/usr/bin/jq -Rn --arg path "$repo_root" '$path')
+while IFS= read -r line || [ -n "$line" ]; do
+    line=${line//@WASM_BINDGEN_MINIMUM@/$minimum_version}
+    line=${line//@TSIFY_PATH@/$tsify_path}
+    printf '%s\n' "$line"
+done < "$manifest_template" > "$probe_dir/Cargo.toml"
+cp "$source_file" "$probe_dir/entry_point.rs"
+
+echo ""
+echo "Building dev descriptor probe with wasm-bindgen $minimum_version"
+echo "Source: $source_file"
+echo ""
+
+(
+    cd "$probe_dir"
+    wasm-pack build --target nodejs --dev
+)

--- a/tests-e2e/minimum_wasm_bindgen.Cargo.toml
+++ b/tests-e2e/minimum_wasm_bindgen.Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "minimum_wasm_bindgen"
+publish = false
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Replaced from the root tsify manifest by build_minimum_wasm_bindgen.sh.
+wasm-bindgen = "=@WASM_BINDGEN_MINIMUM@"
+tsify = { path = @TSIFY_PATH@, default-features = false, features = ["js"] }
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+path = "entry_point.rs"
+crate-type = ["cdylib"]
+
+# The generated crate is deliberately isolated from tsify's workspace so its
+# exact minimum dependency does not change resolution for the normal suite.
+[workspace]

--- a/tests-e2e/minimum_wasm_bindgen.rs
+++ b/tests-e2e/minimum_wasm_bindgen.rs
@@ -1,0 +1,31 @@
+#![allow(dead_code)]
+
+// This is a build-success gate, not another declaration snapshot. These are the
+// four arguments whose names #129's descriptor-facing code must evaluate once
+// it is connected. At the declared wasm-bindgen minimum, a dev build rejects
+// the control flow used by maps and wide integers and the unaligned byte access
+// used by tuples and options. Keeping all four in one tiny crate covers both
+// failure modes without rebuilding the reference-output suite or comparing a
+// pkg/*.d.ts file.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tsify::{Ts, Tsify};
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Serialize, Deserialize)]
+pub struct Envelope<T> {
+    value: T,
+}
+
+#[wasm_bindgen]
+pub fn tuple(_value: Ts<Envelope<(u32, u32)>>) {}
+
+#[wasm_bindgen]
+pub fn option(_value: Ts<Envelope<Option<u32>>>) {}
+
+#[wasm_bindgen]
+pub fn map(_value: Ts<Envelope<HashMap<String, u32>>>) {}
+
+#[wasm_bindgen]
+pub fn wide_integer(_value: Ts<Envelope<u64>>) {}


### PR DESCRIPTION
wasm-bindgen evaluates descriptors with its own interpreter, and the one at the
version we claim to support cannot execute control flow or unaligned byte
access left in a dev module. Release optimization folds both away. So a
descriptor can be wrong in a way only a dev build at `0.2.104` says out loud,
and `tests-e2e/build_all.sh` builds every crate in release.

## Why it has to be both

Measured with a probe that reaches four descriptor paths:

| | dev | release `--no-opt` |
|---|---|---|
| `=0.2.104` | **4 of 4 fail** | all pass |
| `0.2.127` (what Cargo resolves today) | all pass | all pass |

The bottom row is why this is not simply "also build in dev": at the current
version the failures are gone, because 0.2.126 taught the interpreter about
branches and 0.2.127 relaxed the alignment check. Neither half of the gate is
a test on its own.

## What it does not do

**It guards nothing on `main` today.** `describe()` delegates to wasm-bindgen's
own `typescript_type` expansion, which is immediate-only, so this passes for a
reason unrelated to what it is for.

It is landing now rather than later because the order cannot be reversed. #129
adds a descriptor path of our own, and #109 connects it; a gate added after
that lands leaves the landing itself uncovered. The four types in the probe are
the ones whose names that path will evaluate.

The defect this was written for was found by hand, not by this gate — see the
review on #129. This is what keeps it from coming back.

## Cost

About 12s locally. I expected worse on CI: locally wasm-pack falls back to
building the CLI from source for this version, and the cache directory is named
`wasm-bindgen-cargo-install-0.2.104`. Measured on this PR, it does not — the
Test job took 275s against 243-254s for the three runs before it on `main`, so
roughly **half a minute**, not the minutes I assumed. Whatever makes the
difference, the Linux runner does not pay what a local macOS build does.

## How it was checked

- Passes on `main`, reporting `Building dev descriptor probe with wasm-bindgen 0.2.104`
- Fails, `exit 1`, on a descriptor with a loop in it — `unknown instruction Loop(Loop`
- Rejects a version requirement that is not a plain `^x.y.z`, so the floor
  cannot drift from the root manifest without the extraction saying so
- `./test.sh`, `cargo clippy --all-targets`, `cargo fmt --all -- --check` clean

The second commit fixes a regression the first one introduced: making `ROOT_DIR`
absolute put the checkout path in front of every `find` result, and the loop
below split it on whitespace.

ref #129

